### PR TITLE
DockFlare Hotfix v1.8.7: Critical Agent Startup Fix

### DIFF
--- a/dockflare/app/core/cloudflare_api.py
+++ b/dockflare/app/core/cloudflare_api.py
@@ -232,16 +232,25 @@ def get_tunnel_token_via_api(tunnel_id):
     logging.info(f"Getting token for tunnel ID '{tunnel_id}' on account {config.CF_ACCOUNT_ID}")
     endpoint = f"/accounts/{config.CF_ACCOUNT_ID}/cfd_tunnel/{tunnel_id}/token"
     url = f"{config.CF_API_BASE_URL}{endpoint}"
+    token = None
     try:
         logging.info(f"API Request: GET {url} (for token, raw request)")
         response = requests.request("GET", url, headers={"Authorization": f"Bearer {config.CF_API_TOKEN}"}, timeout=30)
         response.raise_for_status()
-        token = response.text.strip()
+        try:
+            token = response.json().get("result")
+            logging.info("Successfully parsed tunnel token from JSON response.")
+        except json.JSONDecodeError:
+            # If JSON parsing fails, it's the legacy raw text response. Bugfix for Issue 83
+            logging.info("Could not parse response as JSON, falling back to raw text for token.")
+            token = response.text.strip()
         if not token or len(token) < 50:
-            logging.error(f"Retrieved token for tunnel {tunnel_id} appears invalid (too short or empty).")
-            raise ValueError("Invalid token format received from API")
-        logging.info(f"Successfully retrieved token for tunnel {tunnel_id}")
+            logging.error(f"Retrieved token for tunnel {tunnel_id} appears invalid (too short or empty). Value: '{token}'")
+            raise ValueError("Invalid token format or content received from API")
+        
+        logging.info(f"Successfully retrieved and validated token for tunnel {tunnel_id}")
         return token
+
     except requests.exceptions.RequestException as e:
         error_msg = f"API Error getting token for tunnel {tunnel_id}: {e}"
         if e.response is not None:

--- a/dockflare/app/main.py
+++ b/dockflare/app/main.py
@@ -179,7 +179,7 @@ def main_application_entrypoint():
 
     logging.info("-" * 52)
     logging.info("--- DockFlare Starting ---")
-    logging.info(f"--- Version: 1.8.6 ---") 
+    logging.info(f"--- Version: 1.8.7 ---") 
     logging.info("-" * 52)
 
     load_state() 

--- a/dockflare/app/templates/status_page.html
+++ b/dockflare/app/templates/status_page.html
@@ -21,7 +21,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>DockFlare v1.8.6 - Cloudflare Tunnel ingress Manager</title>
+    <title>DockFlare v1.8.7 - Cloudflare Tunnel ingress Manager</title>
  
     <link rel="stylesheet" href="{{ url_for('static', filename='css/output.css') }}">
     <link rel="preconnect" href="https://rsms.me" crossorigin>
@@ -43,7 +43,7 @@
 <body class="min_h-screen flex flex-col font-sans transition-colors duration-300">
     <div class="fixed bottom-6 right-[-38px] sm:bottom-7 sm:right-[-35px] z-50 transform -rotate-45 bg-indigo-600 text-white text-xs font-semibold tracking-wider text-center py-1 w-36 shadow-md"
          style="pointer-events: none;">
-        version 1.8.6
+        version 1.8.7
     </div>
 
    <header class="sticky top-0 z-40 w-full backdrop-blur-sm shadow-sm bg-base-100/90">
@@ -446,7 +446,7 @@
             <p class="mb-1"><a href="https://github.com/ChrispyBacon-dev/DockFlare/wiki" target="_blank" rel="noopener noreferrer" class="link link-hover link-primary">DockFlare Documentation</a></p>
             <p class="mb-1">Enjoying DockFlare? Consider supporting the project!</p>
             <p><a href="https://github.com/sponsors/ChrispyBacon-dev" target="_blank" rel="noopener noreferrer" class="inline-flex items-center link link-hover"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1 text-pink-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd" /></svg>Sponsor ChrispyBacon-dev on GitHub</a></p>
-            <p class="mt-2 text-xs opacity-60">DockFlare v1.8.6</p>
+            <p class="mt-2 text-xs opacity-60">DockFlare v1.8.7</p>
         </div>
     </footer>
 <dialog id="add_manual_rule_modal" class="modal">


### PR DESCRIPTION
### **Hotfix v1.8.7: Critical Agent Startup Fix**

I've just released a critical hotfix that resolves a bug preventing the managed `cloudflared` agent from starting correctly.

**The Issue:**
Some of you may have seen the `Provided Tunnel token is not valid` error from the `cloudflared` container. 

**The Fix:**
I've updated the code to be more robust. It now correctly handles both the new JSON format and the original raw text format, ensuring the agent will start reliably for everyone.

A huge thank you to the community for reporting and diagnosing this in [GitHub Issue #101](https://github.com/ChrispyBacon-dev/DockFlare/issues/101).

**How to Upgrade:**
To apply the fix, just pull the latest image:

```sh
docker-compose pull
docker-compose up -d
```