### PR TITLE
added HTTP Host Header Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.2] - 2025-06-25
+
+### Added
+- **HTTP Host Header Support:** Implemented support for the new `dockflare.httpHostHeader` Docker label, allowing users to override the `Host` header sent to their origin service. This feature is also fully supported for manual ingress rules via the web UI (Add/Edit modals and display in the Managed Rules table). Applies only to HTTP/HTTPS services.
+
 ## [1.9.1] - 2025-06-23
 
 ### Added

--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/ChrispyBacon-dev/DockFlare)
 [![OS](https://img.shields.io/badge/os-linux%20%7C%20windows%20%7C%20macos-brightgreen)]()
 [![CPU Architectures](https://img.shields.io/badge/CPU-x86_64%20%7C%20arm64-brightgreen)](https://en.wikipedia.org/wiki/Central_processing_unit)
-[![Generic badge](https://img.shields.io/badge/Release-1.9.1-blue.svg)](https://github.com/ChrispyBacon-dev/DockFlare/releases/tag/v1.8.9)
+[![Generic badge](https://img.shields.io/badge/Release-1.9.2-blue.svg)](https://github.com/ChrispyBacon-dev/DockFlare/releases/tag/v1.8.9)
 [![Docker Pulls](https://img.shields.io/docker/pulls/alplat/dockflare)](https://hub.docker.com/r/alplat/dockflare)
 [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/)
 [![GitHub issues](https://img.shields.io/github/issues/ChrispyBacon-dev/dockflare)](https://github.com/ChrispyBacon-dev/dockflare/issues)
@@ -25,6 +25,7 @@ DockFlare simplifies Cloudflare Tunnel and Zero Trust Access policy management b
     -   Auto-configures Tunnel ingress & DNS from Docker labels using the new `dockflare.*` prefix (backward compatible with `cloudflare.tunnel.*`).
     -   Supports various service types (`http`, `https`, `tcp`, `ssh`, `rdp`, `http_status`).
     -   Controls `no_tls_verify` and `originServerName` (SNI) for origin connections.
+    -   **NEW:** Define `httpHostHeader` to override the Host header sent to your origin service.
 -   **Flexible Routing: Multi-Path, Multi-Hostname & Multi-Zone**:
     -   **NEW:** Route multiple URL paths on the same hostname to a single service (e.g., `app.com/api` and `app.com/web`).
     -   Supports multiple hostnames (unique targets, zones, policies) per Docker container using indexed labels.
@@ -326,6 +327,10 @@ services:
 
       # Optional: Specify Origin Server Name (SNI) for TLS connection to origin
       # - "dockflare.originsrvname=internal.service.local" 
+
+      # Optional: Override the HTTP Host header sent to the origin
+      # Applies only to HTTP/HTTPS services.
+      # - "dockflare.httpHostHeader=actual.backend.host"
     networks:
       - cloudflare-net 
 ```
@@ -344,11 +349,13 @@ services:
       # --- Rule 0: Root path (/) for api.example.com ---
       - "dockflare.0.hostname=api.example.com"
       - "dockflare.0.service=http://my-api-gateway:80"
+      - "dockflare.0.httpHostHeader=internal-api-service" # Specific Host header for this rule
       
       # --- Rule 1: /v1 path for api.example.com ---
       - "dockflare.1.hostname=api.example.com"
       - "dockflare.1.path=/v1"
       - "dockflare.1.service=http://my-api-gateway:80"
+      - "dockflare.1.no_tls_verify=true"
       
       # --- Rule 2: A different hostname and service on the same container ---
       - "dockflare.2.hostname=status.example.com"
@@ -543,3 +550,4 @@ Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) or open
 ## 📜 License
 
 DockFlare is licensed under the GNU General Public License v3.0. See [LICENSE.MD](LICENSE.MD) for details.
+```

--- a/dockflare/app/core/docker_handler.py
+++ b/dockflare/app/core/docker_handler.py
@@ -110,6 +110,7 @@ def process_container_start(container_obj):
         
         default_path_label = get_label(labels, "path") 
         default_originsrvname_label = get_label(labels, "originsrvname")
+        default_http_host_header_label = get_label(labels, "httpHostHeader")
         default_access_policy_type_label = get_label(labels, "access.policy")
         default_access_app_name_label = get_label(labels, "access.name")
         default_access_session_duration_label = get_label(labels, "access.session_duration", "24h")
@@ -117,7 +118,6 @@ def process_container_start(container_obj):
         default_access_allowed_idps_label_str = get_label(labels, "access.allowed_idps")
         default_access_auto_redirect_label = get_label(labels, "access.auto_redirect_to_identity", "false").lower() in ["true", "1", "t", "yes"]
         default_access_custom_rules_label_str = get_label(labels, "access.custom_rules")
-
         hostname_label = get_label(labels, "hostname")
         service_label = get_label(labels, "service")
         zone_name_label = get_label(labels, "zonename")
@@ -130,6 +130,7 @@ def process_container_start(container_obj):
                     "path": default_path_label, 
                     "no_tls_verify": no_tls_verify_label,
                     "origin_server_name": default_originsrvname_label.strip() if default_originsrvname_label else None,
+                    "http_host_header": default_http_host_header_label.strip() if default_http_host_header_label else None,
                     "access_policy_type": default_access_policy_type_label, 
                     "access_app_name": default_access_app_name_label,
                     "access_session_duration": default_access_session_duration_label, 
@@ -154,7 +155,7 @@ def process_container_start(container_obj):
             no_tls_verify_indexed_val = get_label(labels, f"{index}.no_tls_verify", str(no_tls_verify_label).lower())
             no_tls_verify_indexed = no_tls_verify_indexed_val.lower() in ["true", "1", "t", "yes"]
             originsrvname_indexed_val = get_label(labels, f"{index}.originsrvname", default_originsrvname_label)
-            
+            http_host_header_indexed_val = get_label(labels, f"{index}.httpHostHeader", default_http_host_header_label)
             access_policy_type_indexed = get_label(labels, f"{index}.access.policy", default_access_policy_type_label)
             access_app_name_indexed = get_label(labels, f"{index}.access.name", default_access_app_name_label)
             access_session_duration_indexed = get_label(labels, f"{index}.access.session_duration", default_access_session_duration_label)
@@ -171,6 +172,7 @@ def process_container_start(container_obj):
                     "path": path_indexed, 
                     "no_tls_verify": no_tls_verify_indexed,
                     "origin_server_name": originsrvname_indexed_val.strip() if originsrvname_indexed_val else None,
+                    "http_host_header": http_host_header_indexed_val.strip() if http_host_header_indexed_val else None,
                     "access_policy_type": access_policy_type_indexed, 
                     "access_app_name": access_app_name_indexed,
                     "access_session_duration": access_session_duration_indexed, 
@@ -198,6 +200,7 @@ def process_container_start(container_obj):
             zone_name_from_item = config_item["zone_name"] 
             no_tls_verify_from_item = config_item["no_tls_verify"] 
             origin_server_name_from_item = config_item.get("origin_server_name")
+            http_host_header_from_item = config_item.get("http_host_header")
 
             target_zone_id = None
             if zone_name_from_item:
@@ -231,6 +234,7 @@ def process_container_start(container_obj):
                     if existing_rule.get("zone_id") != target_zone_id: existing_rule["zone_id"] = target_zone_id; rule_data_changed = True
                     if existing_rule.get("no_tls_verify") != no_tls_verify_from_item: existing_rule["no_tls_verify"] = no_tls_verify_from_item; rule_data_changed = True
                     if existing_rule.get("origin_server_name") != origin_server_name_from_item: existing_rule["origin_server_name"] = origin_server_name_from_item; rule_data_changed = True
+                    if existing_rule.get("http_host_header") != http_host_header_from_item: existing_rule["http_host_header"] = http_host_header_from_item; rule_data_changed = True
                     
                     existing_rule["source"] = "docker"
 
@@ -258,6 +262,7 @@ def process_container_start(container_obj):
                         "zone_id": target_zone_id,
                         "no_tls_verify": no_tls_verify_from_item,
                         "origin_server_name": origin_server_name_from_item,
+                        "http_host_header": http_host_header_from_item,
                         "access_app_id": None, 
                         "access_policy_type": None, 
                         "access_app_config_hash": None, 

--- a/dockflare/app/core/reconciler.py
+++ b/dockflare/app/core/reconciler.py
@@ -47,6 +47,8 @@ def _get_hostname_configs_from_container(container_obj):
 
     default_path_label = get_label(labels, "path")
     default_originsrvname_label = get_label(labels, "originsrvname")
+    default_http_host_header_label = get_label(labels, "httpHostHeader")
+
     default_access_policy_type = get_label(labels, "access.policy")
     default_access_app_name = get_label(labels, "access.name")
     default_session_duration = get_label(labels, "access.session_duration", "24h")
@@ -67,6 +69,7 @@ def _get_hostname_configs_from_container(container_obj):
             "path": default_path_label, 
             "no_tls_verify": ntv_main,
             "origin_server_name": default_originsrvname_label.strip() if default_originsrvname_label else None,
+            "http_host_header": default_http_host_header_label.strip() if default_http_host_header_label else None,
             "container_id": container_id_val, "container_name": container_name_val,
             "access_policy_type": default_access_policy_type,
             "access_app_name": default_access_app_name,
@@ -91,6 +94,7 @@ def _get_hostname_configs_from_container(container_obj):
         ntv_idx_str = get_label(labels, f"{idx}.no_tls_verify", ntv_main_str) 
         ntv_idx = ntv_idx_str.lower() in ["true", "1", "t", "yes"]
         osn_idx_val = get_label(labels, f"{idx}.originsrvname", default_originsrvname_label)
+        h_h_h_idx_val = get_label(labels, f"{idx}.httpHostHeader", default_http_host_header_label)
 
         acc_pol_idx = get_label(labels, f"{idx}.access.policy", default_access_policy_type)
         acc_name_idx = get_label(labels, f"{idx}.access.name", default_access_app_name)
@@ -107,6 +111,7 @@ def _get_hostname_configs_from_container(container_obj):
             "path": path_idx, 
             "no_tls_verify": ntv_idx,
             "origin_server_name": osn_idx_val.strip() if osn_idx_val else None,
+            "http_host_header": h_h_h_idx_val.strip() if h_h_h_idx_val else None,
             "container_id": container_id_val, "container_name": container_name_val,
             "access_policy_type": acc_pol_idx, "access_app_name": acc_name_idx,
             "access_session_duration": acc_sess_idx, "access_app_launcher_visible": acc_vis_idx,
@@ -205,6 +210,7 @@ def _run_reconciliation_logic():
                         "status": "active", "delete_at": None, "zone_id": target_zone_id,
                         "no_tls_verify": desired_details["no_tls_verify"],
                         "origin_server_name": desired_details.get("origin_server_name"),
+                        "http_host_header": desired_details.get("http_host_header"),
                         "access_app_id": None, "access_policy_type": None, "access_app_config_hash": None,
                         "access_policy_ui_override": False, "source": "docker"
                     }
@@ -229,6 +235,8 @@ def _run_reconciliation_logic():
                         existing_rule["path"] = desired_details.get("path"); changed_in_reconcile = True; needs_tunnel_config_update = True
                     if existing_rule.get("origin_server_name") != desired_details.get("origin_server_name"):
                         existing_rule["origin_server_name"] = desired_details.get("origin_server_name"); changed_in_reconcile = True; needs_tunnel_config_update = True
+                    if existing_rule.get("http_host_header") != desired_details.get("http_host_header"):
+                        existing_rule["http_host_header"] = desired_details.get("http_host_header"); changed_in_reconcile = True; needs_tunnel_config_update = True
 
                     existing_rule["source"] = "docker" 
                     if changed_in_reconcile: state_changed_locally = True

--- a/dockflare/app/core/state_manager.py
+++ b/dockflare/app/core/state_manager.py
@@ -93,6 +93,7 @@ def load_state():
                 rule_copy.setdefault("access_policy_ui_override", False)
                 rule_copy.setdefault("source", "docker")
                 rule_copy.setdefault("path", None)
+                rule_copy.setdefault("http_host_header", None)
                 
                 managed_rules[final_key] = rule_copy
 
@@ -134,6 +135,7 @@ def save_state():
                 "zone_id": rule.get("zone_id"), 
                 "no_tls_verify": rule.get("no_tls_verify", False),
                 "origin_server_name": rule.get("origin_server_name"), 
+                "http_host_header": rule.get("http_host_header"),
                 "access_app_id": rule.get("access_app_id"), 
                 "access_policy_type": rule.get("access_policy_type"),
                 "access_app_config_hash": rule.get("access_app_config_hash"),

--- a/dockflare/app/core/tunnel_manager.py
+++ b/dockflare/app/core/tunnel_manager.py
@@ -108,6 +108,8 @@ def update_cloudflare_config():
                 if service_str and actual_hostname_for_cf: 
                     no_tls_verify_flag = rule_details.get("no_tls_verify", False) 
                     origin_server_name_val = rule_details.get("origin_server_name")
+                    http_host_header_val = rule_details.get("http_host_header")
+
                     rule_config = {"hostname": actual_hostname_for_cf, "service": service_str} 
                     
                     if actual_path_for_cf and actual_path_for_cf.strip(): 
@@ -130,7 +132,11 @@ def update_cloudflare_config():
                         origin_request_settings["originServerName"] = origin_server_name_val
                     elif origin_server_name_val:
                         logging.debug(f"Rule for {rule_key} has origin_server_name='{origin_server_name_val}', but service '{service_str}' is not HTTP/HTTPS. 'originServerName' might be ignored by Cloudflare for this service type or cause issues.")
-
+                    if http_host_header_val and isinstance(service_str, str) and \
+                       (service_str.lower().startswith("http://") or service_str.lower().startswith("https://")):
+                        origin_request_settings["httpHostHeader"] = http_host_header_val
+                    elif http_host_header_val:
+                        logging.debug(f"Rule for {rule_key} has http_host_header='{http_host_header_val}', but service '{service_str}' is not HTTP/HTTPS. 'httpHostHeader' might be ignored by Cloudflare for this service type or cause issues.")
                     if origin_request_settings:
                         rule_config["originRequest"] = origin_request_settings
                     
@@ -232,6 +238,9 @@ def update_cloudflare_config():
                     comp_dict["noTLSVerify"] = True 
                 if origin_request.get("originServerName"):
                     comp_dict["originServerName"] = origin_request.get("originServerName")
+                if origin_request.get("httpHostHeader"):
+                    comp_dict["httpHostHeader"] = origin_request.get("httpHostHeader")
+
             return comp_dict
 
         current_api_comparable_set = {json.dumps(rule_to_comparable_dict(r), sort_keys=True) for r in current_api_ingress_rules}

--- a/dockflare/app/main.py
+++ b/dockflare/app/main.py
@@ -174,7 +174,7 @@ def main_application_entrypoint():
 
     logging.info("-" * 52)
     logging.info("--- DockFlare Starting ---")
-    logging.info(f"--- Version: 1.9.1 ---") 
+    logging.info(f"--- Version: 1.9.2 ---") 
     logging.info("-" * 52)
 
     load_state() 

--- a/dockflare/app/static/js/main.js
+++ b/dockflare/app/static/js/main.js
@@ -141,7 +141,7 @@ function initializeEditManualRuleModal() {
                 modal.querySelector('#edit_manual_zone_name_override').value = '';
                 modal.querySelector('#edit_manual_no_tls_verify').checked = details.no_tls_verify || false;
                 modal.querySelector('#edit_manual_origin_server_name').value = details.origin_server_name || '';
-
+                modal.querySelector('#edit_manual_http_host_header').value = details.http_host_header || '';
                 modal.showModal();
             } catch (e) {
                 console.error("Error populating edit modal:", e);

--- a/dockflare/app/templates/status_page.html
+++ b/dockflare/app/templates/status_page.html
@@ -21,7 +21,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>DockFlare v1.9.1 - Cloudflare Tunnel ingress Manager</title>
+    <title>DockFlare v1.9.2 - Cloudflare Tunnel ingress Manager</title>
  
     <link rel="stylesheet" href="{{ url_for('static', filename='css/output.css') }}">
     <link rel="preconnect" href="https://rsms.me" crossorigin>
@@ -43,7 +43,7 @@
 <body class="min_h-screen flex flex-col font-sans transition-colors duration-300">
     <div class="fixed bottom-6 right-[-38px] sm:bottom-7 sm:right-[-35px] z-50 transform -rotate-45 bg-indigo-600 text-white text-xs font-semibold tracking-wider text-center py-1 w-36 shadow-md"
          style="pointer-events: none;">
-        version 1.9.1
+        version 1.9.2
     </div>
 
    <header class="sticky top-0 z-40 w-full backdrop-blur-sm shadow-sm bg-base-100/90">
@@ -240,6 +240,9 @@
                                                {% if details.origin_server_name %}
                                                    <span class="badge badge-info badge-xs ml-1" title="Origin Server Name (SNI): {{ details.origin_server_name }}">SNI: {{ details.origin_server_name | truncate(20, True) }}</span>
                                                {% endif %}
+                                               {% if details.http_host_header %}
+                                                   <span class="badge badge-info badge-xs ml-1" title="HTTP Host Header: {{ details.http_host_header }}">Host: {{ details.http_host_header | truncate(20, True) }}</span>
+                                               {% endif %}    
                                            </div>
                                    </td>
                                        <td class="p-3 whitespace-nowrap">
@@ -446,7 +449,7 @@
             <p class="mb-1"><a href="https://github.com/ChrispyBacon-dev/DockFlare/wiki" target="_blank" rel="noopener noreferrer" class="link link-hover link-primary">DockFlare Documentation</a></p>
             <p class="mb-1">Enjoying DockFlare? Consider supporting the project!</p>
             <p><a href="https://github.com/sponsors/ChrispyBacon-dev" target="_blank" rel="noopener noreferrer" class="inline-flex items-center link link-hover"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1 text-pink-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd" /></svg>Sponsor ChrispyBacon-dev on GitHub</a></p>
-            <p class="mt-2 text-xs opacity-60">DockFlare v1.9.1</p>
+            <p class="mt-2 text-xs opacity-60">DockFlare v1.9.2</p>
         </div>
     </footer>
 <dialog id="add_manual_rule_modal" class="modal">
@@ -553,6 +556,17 @@
                         <span class="label-text-alt">Specify the hostname Cloudflare should use for TLS SNI when connecting to your origin. Leave blank if not needed. (Only applies to HTTP/HTTPS services).</span>
                     </label>
                 </div>
+                    <div class="form-control">
+                    <label class="label" for="manual_http_host_header">
+                        <span class="label-text">HTTP Host Header (Optional)</span>
+                    </label>
+                    <input type="text" id="manual_http_host_header" name="manual_http_host_header"
+                           placeholder="e.g., api.example.com"
+                           class="input input-bordered w-full" />
+                    <label class="label">
+                        <span class="label-text-alt">Overrides the <code>Host</code> header sent to your origin server. Useful for origins expecting a different hostname than the public one. (Only applies to HTTP/HTTPS services).</span>
+                    </label>
+                </div>
             <div class="modal-action mt-8">
               <button type="submit" class="btn btn-primary">Add Rule</button>
             </div>
@@ -644,6 +658,17 @@
                 <div class="form-control" id="edit_manual_origin_server_name_div">
                     <label class="label" for="edit_manual_origin_server_name"><span class="label-text">Origin Server Name (SNI)</span></label>
                     <input type="text" id="edit_manual_origin_server_name" name="manual_origin_server_name" placeholder="e.g., internal.service.local" class="input input-bordered w-full" />
+                </div>
+                        <div class="form-control">
+                    <label class="label" for="edit_manual_http_host_header">
+                        <span class="label-text">HTTP Host Header (Optional)</span>
+                    </label>
+                    <input type="text" id="edit_manual_http_host_header" name="manual_http_host_header"
+                           placeholder="e.g., api.example.com"
+                           class="input input-bordered w-full" />
+                    <label class="label">
+                        <span class="label-text-alt">Overrides the <code>Host</code> header sent to your origin server. Useful for origins expecting a different hostname than the public one. (Only applies to HTTP/HTTPS services).</span>
+                    </label>
                 </div>
             </div>
             <div class="modal-action mt-8">

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -448,6 +448,8 @@ def ui_add_manual_rule_route():
     zone_name_override_input = request.form.get('manual_zone_name_override', '').strip()
     no_tls_verify = request.form.get('manual_no_tls_verify') == 'on'
     origin_server_name_input = request.form.get('manual_origin_server_name', '').strip()
+    manual_http_host_header = request.form.get('manual_http_host_header', '').strip()
+
     manual_access_policy_type = request.form.get('manual_access_policy_type', 'none').strip().lower()
     manual_auth_email = request.form.get('manual_auth_email', '').strip()
 
@@ -611,6 +613,7 @@ def ui_add_manual_rule_route():
             "zone_id": target_zone_id, 
             "no_tls_verify": no_tls_verify,
             "origin_server_name": origin_server_name_input if origin_server_name_input else None,
+            "http_host_header": manual_http_host_header if manual_http_host_header else None,
             "access_app_id": access_app_created_or_updated_id if manual_access_policy_type in ["bypass", "authenticate_email"] \
                              else (existing_rule_details.get("access_app_id") if existing_rule_details else None),
             "access_policy_type": manual_access_policy_type if manual_access_policy_type != "none" else None,
@@ -766,6 +769,7 @@ def ui_edit_manual_rule_route():
     zone_name_override_input = request.form.get('manual_zone_name_override', '').strip()
     no_tls_verify = request.form.get('manual_no_tls_verify') == 'on'
     origin_server_name_input = request.form.get('manual_origin_server_name', '').strip()
+    manual_http_host_header = request.form.get('manual_http_host_header', '').strip()
     manual_access_policy_type = request.form.get('manual_access_policy_type', 'none').strip().lower()
     manual_auth_email = request.form.get('manual_auth_email', '').strip()
     
@@ -846,6 +850,7 @@ def ui_edit_manual_rule_route():
             "service": processed_service_for_cf, "path": processed_path, "hostname_for_dns": full_hostname, 
             "container_id": None, "status": "active", "delete_at": None, "zone_id": target_zone_id, 
             "no_tls_verify": no_tls_verify, "origin_server_name": origin_server_name_input or None,
+            "http_host_header": manual_http_host_header if manual_http_host_header else None,
             "access_app_id": access_app_created_or_updated_id, "access_policy_type": manual_access_policy_type if manual_access_policy_type != "none" else None,
             "access_app_config_hash": access_app_final_config_hash, "auth_email": manual_auth_email if manual_access_policy_type == "authenticate_email" else None,
             "access_policy_ui_override": True if manual_access_policy_type != "none" else False, "source": "manual"


### PR DESCRIPTION
## [1.9.2] - 2025-06-25

### Added
- **HTTP Host Header Support:** Implemented support for the new `dockflare.httpHostHeader` Docker label, allowing users to override the `Host` header sent to their origin service. This feature is also fully supported for manual ingress rules via the web UI (Add/Edit modals and display in the Managed Rules table). Applies only to HTTP/HTTPS services.