### PR TITLE
[1.9.3] - 2025-07-19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **HTTP Host Header Support:** Implemented support for the new `dockflare.httpHostHeader` Docker label, allowing users to override the `Host` header sent to their origin service. This feature is also fully supported for manual ingress rules via the web UI (Add/Edit modals and display in the Managed Rules table). Applies only to HTTP/HTTPS services.
 
+### Fixed
+- **Service Validation for Docker Names:** Corrected the `is_valid_service` regex to properly allow underscores (`_`) in service hostnames (e.g., `http://my_app:80`), accommodating common Docker service naming conventions.
+
+### Changed
+- **Optional Ports for HTTP/HTTPS Services:** Modified `is_valid_service` to make the port optional for `http://` and `https://` service targets (e.g., `http://my-service` is now valid). Default ports (80 for HTTP, 443 for HTTPS) will be implicitly used by Cloudflare Tunnel if no port is specified.
+
 ## [1.9.1] - 2025-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.9.3] - 2025-07-19
+
+### Fixed
+- **Critical UI Fix for Access Policies:** Resolved a critical bug causing an 'Internal Server Error' when creating or editing manual rules, or updating a Docker-managed rule's policy, to use the 'Authenticate by Email' method via the web UI. This was a regression caused by recent updates to the Cloudflare Access API handling in `access_manager.py` which were not reflected in the UI routes. The routes in `app/web/routes.py` have been updated to correctly construct the Access Policy payload, resolving the `TypeError` and API validation errors.
+- **Service Validation for Docker Names:** Corrected the `is_valid_service` validation regex to properly allow underscores (`_`) in service hostnames (e.g., `http://my_app:80`), accommodating common Docker service naming conventions.
+
+### Changed
+- **Optional Ports for HTTP/HTTPS Services:** Modified the `is_valid_service` validation to make the port optional for `http://` and `https://` service targets (e.g., `http://my-service` is now valid). Cloudflare Tunnel will implicitly use the default ports (80 for HTTP, 443 for HTTPS) if none are specified.
+
 ## [1.9.2] - 2025-06-25
 
 ### Added

--- a/dockflare/app/core/docker_handler.py
+++ b/dockflare/app/core/docker_handler.py
@@ -56,7 +56,7 @@ def is_valid_service(service_str):
     service_str = service_str.strip()
     # Regex patterns for different service types
 
-    # Hostname/IP part: Allows domain names, IPv4, and bracketed IPv6 // update issue 132 , allow _ character for internal docker services, please not for external DNS _ character is not allowed
+    # Hostname/IP for service targets: Allows domain names (includes '_' for Docker service names, per #132), IPv4, and bracketed IPv6. (Note: '_' is not valid for public DNS hostnames).
     host_ip_pattern = r"([a-zA-Z0-9_](?:[a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9_])?(?:\.[a-zA-Z0-9_](?:[a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9_])?)*\.?|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|\[[0-9a-fA-F:]+\])"
     port_pattern = r"[0-9]{1,5}" # Ports 0-65535
 

--- a/dockflare/app/core/docker_handler.py
+++ b/dockflare/app/core/docker_handler.py
@@ -56,12 +56,13 @@ def is_valid_service(service_str):
     service_str = service_str.strip()
     # Regex patterns for different service types
 
-    # Hostname/IP part: Allows domain names, IPv4, and bracketed IPv6
-    host_ip_pattern = r"([a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*\.?|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|\[[0-9a-fA-F:]+\])"
+    # Hostname/IP part: Allows domain names, IPv4, and bracketed IPv6 // update issue 132 , allow _ character for internal docker services, please not for external DNS _ character is not allowed
+    host_ip_pattern = r"([a-zA-Z0-9_](?:[a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9_])?(?:\.[a-zA-Z0-9_](?:[a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9_])?)*\.?|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|\[[0-9a-fA-F:]+\])"
     port_pattern = r"[0-9]{1,5}" # Ports 0-65535
 
-    # HTTP/HTTPS: http(s)://host:port
-    http_https_pattern = rf"^(?:https?)://{host_ip_pattern}:{port_pattern}$"
+    # HTTP/HTTPS: http(s)://host(:port)? - port is now optional raised by issue 132
+    # The (?:...) makes the group non-capturing, and ? makes the entire group (colon + port) optional.
+    http_https_pattern = rf"^(?:https?)://{host_ip_pattern}(?::{port_pattern})?$"
     
     # TCP: tcp://host:port
     tcp_pattern = rf"^(?:tcp)://{host_ip_pattern}:{port_pattern}$"

--- a/dockflare/app/main.py
+++ b/dockflare/app/main.py
@@ -174,7 +174,7 @@ def main_application_entrypoint():
 
     logging.info("-" * 52)
     logging.info("--- DockFlare Starting ---")
-    logging.info(f"--- Version: 1.9.2 ---") 
+    logging.info(f"--- Version: 1.9.3 ---") 
     logging.info("-" * 52)
 
     load_state() 

--- a/dockflare/app/templates/status_page.html
+++ b/dockflare/app/templates/status_page.html
@@ -21,7 +21,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>DockFlare v1.9.2 - Cloudflare Tunnel ingress Manager</title>
+    <title>DockFlare v1.9.3 - Cloudflare Tunnel ingress Manager</title>
  
     <link rel="stylesheet" href="{{ url_for('static', filename='css/output.css') }}">
     <link rel="preconnect" href="https://rsms.me" crossorigin>
@@ -43,7 +43,7 @@
 <body class="min_h-screen flex flex-col font-sans transition-colors duration-300">
     <div class="fixed bottom-6 right-[-38px] sm:bottom-7 sm:right-[-35px] z-50 transform -rotate-45 bg-indigo-600 text-white text-xs font-semibold tracking-wider text-center py-1 w-36 shadow-md"
          style="pointer-events: none;">
-        version 1.9.2
+        version 1.9.3
     </div>
 
    <header class="sticky top-0 z-40 w-full backdrop-blur-sm shadow-sm bg-base-100/90">
@@ -449,7 +449,7 @@
             <p class="mb-1"><a href="https://github.com/ChrispyBacon-dev/DockFlare/wiki" target="_blank" rel="noopener noreferrer" class="link link-hover link-primary">DockFlare Documentation</a></p>
             <p class="mb-1">Enjoying DockFlare? Consider supporting the project!</p>
             <p><a href="https://github.com/sponsors/ChrispyBacon-dev" target="_blank" rel="noopener noreferrer" class="inline-flex items-center link link-hover"><svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1 text-pink-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd" /></svg>Sponsor ChrispyBacon-dev on GitHub</a></p>
-            <p class="mt-2 text-xs opacity-60">DockFlare v1.9.2</p>
+            <p class="mt-2 text-xs opacity-60">DockFlare v1.9.3</p>
         </div>
     </footer>
 <dialog id="add_manual_rule_modal" class="modal">

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -557,11 +557,15 @@ def ui_add_manual_rule_route():
         custom_rules_for_hash_str = json.dumps(cf_access_policies_for_app)
     
     if manual_access_policy_type in ["bypass", "authenticate_email"]:
+        allowed_idps_list = None
+        if manual_access_policy_type == "authenticate_email":
+            desired_allowed_idps_str = "ea94073b-1175-4089-81a2-3498c8c147b3"
+            allowed_idps_list = [desired_allowed_idps_str]
+        
         existing_cf_app = find_cloudflare_access_application_by_hostname(full_hostname)
         if existing_cf_app and existing_cf_app.get("id"):
             logging.info(f"Manual Add: Found existing Access App {existing_cf_app.get('id')} for {full_hostname}. Will attempt to update it.")
             access_app_created_or_updated_id = existing_cf_app.get("id")
-            allowed_idps_list = [idp.strip() for idp in desired_allowed_idps_str.split(',') if idp.strip()] if desired_allowed_idps_str else None
             updated_app = update_cloudflare_access_application(
                 access_app_created_or_updated_id, full_hostname, desired_app_name,
                 desired_session_duration, desired_app_launcher_visible,
@@ -581,10 +585,10 @@ def ui_add_manual_rule_route():
                 full_hostname, desired_app_name,
                 desired_session_duration, desired_app_launcher_visible,
                 [full_hostname], cf_access_policies_for_app, 
-                [idp.strip() for idp in desired_allowed_idps_str.split(',') if idp.strip()] if desired_allowed_idps_str else None, 
+                allowed_idps_list, 
                 desired_auto_redirect
             )
-            if created_app and created_app.get("id"):
+            if created_and created_app.get("id"):
                 access_app_created_or_updated_id = created_app.get("id")
                 access_app_final_config_hash = generate_access_app_config_hash(
                     manual_access_policy_type, desired_session_duration, desired_app_launcher_visible,
@@ -815,6 +819,9 @@ def ui_edit_manual_rule_route():
     cf_access_policies_for_app = [] 
     
     if manual_access_policy_type in ["bypass", "authenticate_email"]:
+        allowed_idps_for_update = None
+        allowed_idps_str_for_hash = None
+        
         if manual_access_policy_type == "bypass":
             cf_access_policies_for_app = [{"name": "UI Manual Public Bypass", "decision": "bypass", "include": [{"everyone": {}}]}]
         else: 
@@ -822,20 +829,22 @@ def ui_edit_manual_rule_route():
                 {"name": f"UI Manual Allow Email {manual_auth_email}", "decision": "allow", "include": [{"email": {"email": manual_auth_email}}]},
                 {"name": "UI Manual Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]}
             ]
+            allowed_idps_str_for_hash = "ea94073b-1175-4089-81a2-3498c8c147b3"
+            allowed_idps_for_update = [allowed_idps_str_for_hash]
         
         app_id_to_update = old_access_app_id if old_hostname_for_dns == full_hostname else None
         
         if app_id_to_update:
             logging.info(f"Manual Edit: Updating existing Access App {app_id_to_update} for {full_hostname}")
-            updated_app = update_cloudflare_access_application(app_id_to_update, full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, None, False)
+            updated_app = update_cloudflare_access_application(app_id_to_update, full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, allowed_idps_for_update, False)
             if updated_app: access_app_created_or_updated_id = updated_app.get("id")
         else:
             logging.info(f"Manual Edit: Creating new Access App for {full_hostname}")
-            created_app = create_cloudflare_access_application(full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, None, False)
+            created_app = create_cloudflare_access_application(full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, allowed_idps_for_update, False)
             if created_app: access_app_created_or_updated_id = created_app.get("id")
             
         if access_app_created_or_updated_id:
-             access_app_final_config_hash = generate_access_app_config_hash(manual_access_policy_type, "24h", False, None, False, custom_access_rules_str=json.dumps(cf_access_policies_for_app))
+             access_app_final_config_hash = generate_access_app_config_hash(manual_access_policy_type, "24h", False, allowed_idps_str_for_hash, False, custom_access_rules_str=json.dumps(cf_access_policies_for_app))
 
     with state_lock:
         if new_rule_key != original_rule_key and managed_rules.get(new_rule_key, {}).get("source") == "docker":
@@ -880,7 +889,7 @@ def ui_edit_manual_rule_route():
         cloudflared_agent_state["last_action_status"] = f"Error: Failed to update Cloudflare tunnel config for manual rule {full_hostname}."
 
     return redirect(url_for('web.status_page'))
-
+    
 @bp.route('/cloudflare-ping')
 def cloudflare_ping_route(): 
     try:

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -206,25 +206,29 @@ def ui_update_access_policy(hostname):
 
         elif new_policy_type in ["bypass", "authenticate_email"]:
             cf_access_policies = []
+            allowed_idps_str_for_hash = None
+
             if new_policy_type == "bypass":
                 cf_access_policies = [{"name": "UI Public Bypass", "decision": "bypass", "include": [{"everyone": {}}]}]
             elif new_policy_type == "authenticate_email":
                 if not auth_email:
                     cloudflared_agent_state["last_action_status"] = f"Error: Email address required for 'authenticate_email' policy for {fqdn}."
                     return redirect(url_for('web.status_page'))
+                
+                allowed_idps_str_for_hash = "ea94073b-1175-4089-81a2-3498c8c147b3"
                 cf_access_policies = [
                     {"name": f"UI Allow Email {auth_email}", "decision": "allow", "include": [{"email": {"email": auth_email}}]},
-                    {"name": "UI Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]}
+                    {"name": "UI Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]},
+                    {"name": "Enable Email Auth", "decision": "non_identity", "include": [{"login_method": {"id": allowed_idps_str_for_hash}}]}
                 ]
 
             desired_session_duration = request.form.get("session_duration", current_rule.get("access_session_duration", "24h"))
             desired_app_launcher_visible = request.form.get("app_launcher_visible", str(current_rule.get("access_app_launcher_visible", False))).lower() in ["true", "on", "1", "yes"]
-            desired_allowed_idps_str = request.form.get("allowed_idps", current_rule.get("access_allowed_idps_str"))
             desired_auto_redirect = request.form.get("auto_redirect", str(current_rule.get("access_auto_redirect", False))).lower() in ["true", "on", "1", "yes"]
             
             new_config_hash = generate_access_app_config_hash(
                 new_policy_type, 
-                desired_session_duration, desired_app_launcher_visible, desired_allowed_idps_str, desired_auto_redirect,
+                desired_session_duration, desired_app_launcher_visible, allowed_idps_str_for_hash, desired_auto_redirect,
                 custom_access_rules_str=json.dumps(cf_access_policies)
             )
 
@@ -233,7 +237,6 @@ def ui_update_access_policy(hostname):
                 operation_successful = True
             else:
                 desired_app_name = f"DockFlare-{fqdn}"
-                allowed_idps_list = [idp.strip() for idp in desired_allowed_idps_str.split(',') if idp.strip()] if desired_allowed_idps_str else None
                 
                 effective_app_id_for_operation = current_access_app_id
                 if not effective_app_id_for_operation:
@@ -249,14 +252,14 @@ def ui_update_access_policy(hostname):
                     app_result = update_cloudflare_access_application(
                         effective_app_id_for_operation, fqdn, desired_app_name,
                         desired_session_duration, desired_app_launcher_visible,
-                        [fqdn], cf_access_policies, allowed_idps_list, desired_auto_redirect
+                        [fqdn], cf_access_policies, desired_auto_redirect
                     )
                 else: 
                     logging.info(f"UI: Attempting to create Access App. Target Name: {desired_app_name}, Target Policy: {new_policy_type}")
                     app_result = create_cloudflare_access_application(
                         fqdn, desired_app_name,
                         desired_session_duration, desired_app_launcher_visible,
-                        [fqdn], cf_access_policies, allowed_idps_list, desired_auto_redirect
+                        [fqdn], cf_access_policies, desired_auto_redirect
                     )
 
                 if app_result and app_result.get("id"):
@@ -283,7 +286,7 @@ def ui_update_access_policy(hostname):
 @bp.route('/revert_access_policy_to_labels/<path:hostname>', methods=['POST'])
 def revert_access_policy_to_labels(hostname):
     fqdn = hostname.split('|')[0]
-    if not docker_client: # ...
+    if not docker_client: 
         return redirect(url_for('web.status_page'))
     
     action_status_message = f"Attempting to revert Access Policy for '{fqdn}' to label configuration..."
@@ -292,20 +295,19 @@ def revert_access_policy_to_labels(hostname):
 
     with state_lock:
         current_rule = managed_rules.get(hostname)
-        if not current_rule: # ...
+        if not current_rule:
             return redirect(url_for('web.status_page'))
-        if not current_rule.get("access_policy_ui_override", False): # ...
+        if not current_rule.get("access_policy_ui_override", False):
             return redirect(url_for('web.status_page'))
         
         app_id_to_delete_if_any = current_rule.get("access_app_id")
         current_rule["access_policy_ui_override"] = False
-        # ...
         state_changed_for_revert = True
         if state_changed_for_revert: save_state()
 
     if app_id_to_delete_if_any:
         if delete_cloudflare_access_application(app_id_to_delete_if_any): 
-            pass # ...
+            pass
     
     reconcile_state_threaded() 
     action_status_message += " Reconciliation triggered."
@@ -550,18 +552,15 @@ def ui_add_manual_rule_route():
         cf_access_policies_for_app = [{"name": "UI Manual Public Bypass", "decision": "bypass", "include": [{"everyone": {}}]}]
         custom_rules_for_hash_str = json.dumps(cf_access_policies_for_app)
     elif manual_access_policy_type == "authenticate_email":
+        desired_allowed_idps_str = "ea94073b-1175-4089-81a2-3498c8c147b3"
         cf_access_policies_for_app = [
             {"name": f"UI Manual Allow Email {manual_auth_email}", "decision": "allow", "include": [{"email": {"email": manual_auth_email}}]},
-            {"name": "UI Manual Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]}
+            {"name": "UI Manual Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]},
+            {"name": "Enable Email Auth", "decision": "non_identity", "include": [{"login_method": {"id": desired_allowed_idps_str}}]}
         ]
         custom_rules_for_hash_str = json.dumps(cf_access_policies_for_app)
     
     if manual_access_policy_type in ["bypass", "authenticate_email"]:
-        allowed_idps_list = None
-        if manual_access_policy_type == "authenticate_email":
-            desired_allowed_idps_str = "ea94073b-1175-4089-81a2-3498c8c147b3"
-            allowed_idps_list = [desired_allowed_idps_str]
-        
         existing_cf_app = find_cloudflare_access_application_by_hostname(full_hostname)
         if existing_cf_app and existing_cf_app.get("id"):
             logging.info(f"Manual Add: Found existing Access App {existing_cf_app.get('id')} for {full_hostname}. Will attempt to update it.")
@@ -569,7 +568,7 @@ def ui_add_manual_rule_route():
             updated_app = update_cloudflare_access_application(
                 access_app_created_or_updated_id, full_hostname, desired_app_name,
                 desired_session_duration, desired_app_launcher_visible,
-                [full_hostname], cf_access_policies_for_app, allowed_idps_list, desired_auto_redirect
+                [full_hostname], cf_access_policies_for_app, desired_auto_redirect
             )
             if updated_app:
                 access_app_created_or_updated_id = updated_app.get("id")
@@ -585,7 +584,6 @@ def ui_add_manual_rule_route():
                 full_hostname, desired_app_name,
                 desired_session_duration, desired_app_launcher_visible,
                 [full_hostname], cf_access_policies_for_app, 
-                allowed_idps_list, 
                 desired_auto_redirect
             )
             if created_app and created_app.get("id"):
@@ -819,28 +817,27 @@ def ui_edit_manual_rule_route():
     cf_access_policies_for_app = [] 
     
     if manual_access_policy_type in ["bypass", "authenticate_email"]:
-        allowed_idps_for_update = None
         allowed_idps_str_for_hash = None
         
         if manual_access_policy_type == "bypass":
             cf_access_policies_for_app = [{"name": "UI Manual Public Bypass", "decision": "bypass", "include": [{"everyone": {}}]}]
         else: 
+            allowed_idps_str_for_hash = "ea94073b-1175-4089-81a2-3498c8c147b3"
             cf_access_policies_for_app = [
                 {"name": f"UI Manual Allow Email {manual_auth_email}", "decision": "allow", "include": [{"email": {"email": manual_auth_email}}]},
-                {"name": "UI Manual Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]}
+                {"name": "UI Manual Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]},
+                {"name": "Enable Email Auth", "decision": "non_identity", "include": [{"login_method": {"id": allowed_idps_str_for_hash}}]}
             ]
-            allowed_idps_str_for_hash = "ea94073b-1175-4089-81a2-3498c8c147b3"
-            allowed_idps_for_update = [allowed_idps_str_for_hash]
         
         app_id_to_update = old_access_app_id if old_hostname_for_dns == full_hostname else None
         
         if app_id_to_update:
             logging.info(f"Manual Edit: Updating existing Access App {app_id_to_update} for {full_hostname}")
-            updated_app = update_cloudflare_access_application(app_id_to_update, full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, allowed_idps_for_update, False)
+            updated_app = update_cloudflare_access_application(app_id_to_update, full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, False)
             if updated_app: access_app_created_or_updated_id = updated_app.get("id")
         else:
             logging.info(f"Manual Edit: Creating new Access App for {full_hostname}")
-            created_app = create_cloudflare_access_application(full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, allowed_idps_for_update, False)
+            created_app = create_cloudflare_access_application(full_hostname, f"DockFlare-{full_hostname}", "24h", False, [full_hostname], cf_access_policies_for_app, False)
             if created_app: access_app_created_or_updated_id = created_app.get("id")
             
         if access_app_created_or_updated_id:

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -588,7 +588,7 @@ def ui_add_manual_rule_route():
                 allowed_idps_list, 
                 desired_auto_redirect
             )
-            if created_and created_app.get("id"):
+            if created_app created_app.get("id"):
                 access_app_created_or_updated_id = created_app.get("id")
                 access_app_final_config_hash = generate_access_app_config_hash(
                     manual_access_policy_type, desired_session_duration, desired_app_launcher_visible,
@@ -889,7 +889,7 @@ def ui_edit_manual_rule_route():
         cloudflared_agent_state["last_action_status"] = f"Error: Failed to update Cloudflare tunnel config for manual rule {full_hostname}."
 
     return redirect(url_for('web.status_page'))
-    
+
 @bp.route('/cloudflare-ping')
 def cloudflare_ping_route(): 
     try:

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -216,10 +216,13 @@ def ui_update_access_policy(hostname):
                     return redirect(url_for('web.status_page'))
                 
                 allowed_idps_str_for_hash = "ea94073b-1175-4089-81a2-3498c8c147b3"
+                policy_include_rules = [
+                    {"email": {"email": auth_email}},
+                    {"login_method": {"id": allowed_idps_str_for_hash}}
+                ]
                 cf_access_policies = [
-                    {"name": f"UI Allow Email {auth_email}", "decision": "allow", "include": [{"email": {"email": auth_email}}]},
-                    {"name": "UI Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]},
-                    {"name": "Enable Email Auth", "decision": "non_identity", "include": [{"login_method": {"id": allowed_idps_str_for_hash}}]}
+                    {"name": f"UI Allow Access for {auth_email}", "decision": "allow", "include": policy_include_rules},
+                    {"name": "UI Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]}
                 ]
 
             desired_session_duration = request.form.get("session_duration", current_rule.get("access_session_duration", "24h"))
@@ -286,7 +289,7 @@ def ui_update_access_policy(hostname):
 @bp.route('/revert_access_policy_to_labels/<path:hostname>', methods=['POST'])
 def revert_access_policy_to_labels(hostname):
     fqdn = hostname.split('|')[0]
-    if not docker_client: 
+    if not docker_client:
         return redirect(url_for('web.status_page'))
     
     action_status_message = f"Attempting to revert Access Policy for '{fqdn}' to label configuration..."
@@ -553,10 +556,13 @@ def ui_add_manual_rule_route():
         custom_rules_for_hash_str = json.dumps(cf_access_policies_for_app)
     elif manual_access_policy_type == "authenticate_email":
         desired_allowed_idps_str = "ea94073b-1175-4089-81a2-3498c8c147b3"
+        policy_include_rules = [
+            {"email": {"email": manual_auth_email}},
+            {"login_method": {"id": desired_allowed_idps_str}}
+        ]
         cf_access_policies_for_app = [
-            {"name": f"UI Manual Allow Email {manual_auth_email}", "decision": "allow", "include": [{"email": {"email": manual_auth_email}}]},
-            {"name": "UI Manual Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]},
-            {"name": "Enable Email Auth", "decision": "non_identity", "include": [{"login_method": {"id": desired_allowed_idps_str}}]}
+            {"name": f"UI Allow Access for {manual_auth_email}", "decision": "allow", "include": policy_include_rules},
+            {"name": "UI Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]}
         ]
         custom_rules_for_hash_str = json.dumps(cf_access_policies_for_app)
     
@@ -823,10 +829,13 @@ def ui_edit_manual_rule_route():
             cf_access_policies_for_app = [{"name": "UI Manual Public Bypass", "decision": "bypass", "include": [{"everyone": {}}]}]
         else: 
             allowed_idps_str_for_hash = "ea94073b-1175-4089-81a2-3498c8c147b3"
+            policy_include_rules = [
+                {"email": {"email": manual_auth_email}},
+                {"login_method": {"id": allowed_idps_str_for_hash}}
+            ]
             cf_access_policies_for_app = [
-                {"name": f"UI Manual Allow Email {manual_auth_email}", "decision": "allow", "include": [{"email": {"email": manual_auth_email}}]},
-                {"name": "UI Manual Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]},
-                {"name": "Enable Email Auth", "decision": "non_identity", "include": [{"login_method": {"id": allowed_idps_str_for_hash}}]}
+                {"name": f"UI Allow Access for {manual_auth_email}", "decision": "allow", "include": policy_include_rules},
+                {"name": "UI Deny Fallback", "decision": "deny", "include": [{"everyone": {}}]}
             ]
         
         app_id_to_update = old_access_app_id if old_hostname_for_dns == full_hostname else None

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -588,7 +588,7 @@ def ui_add_manual_rule_route():
                 allowed_idps_list, 
                 desired_auto_redirect
             )
-            if created_app created_app.get("id"):
+            if created_app and created_app.get("id"):
                 access_app_created_or_updated_id = created_app.get("id")
                 access_app_final_config_hash = generate_access_app_config_hash(
                     manual_access_policy_type, desired_session_duration, desired_app_launcher_visible,
@@ -889,7 +889,7 @@ def ui_edit_manual_rule_route():
         cloudflared_agent_state["last_action_status"] = f"Error: Failed to update Cloudflare tunnel config for manual rule {full_hostname}."
 
     return redirect(url_for('web.status_page'))
-
+    
 @bp.route('/cloudflare-ping')
 def cloudflare_ping_route(): 
     try:


### PR DESCRIPTION
## [1.9.3] - 2025-07-19

### Fixed
- **Critical UI Fix for Access Policies:** Resolved a critical bug causing an 'Internal Server Error' when creating or editing manual rules, or updating a Docker-managed rule's policy, to use the 'Authenticate by Email' method via the web UI. This was a regression caused by recent updates to the Cloudflare Access API handling in `access_manager.py` which were not reflected in the UI routes. The routes in `app/web/routes.py` have been updated to correctly construct the Access Policy payload, resolving the `TypeError` and API validation errors.
- **Service Validation for Docker Names:** Corrected the `is_valid_service` validation regex to properly allow underscores (`_`) in service hostnames (e.g., `http://my_app:80`), accommodating common Docker service naming conventions.

### Changed
- **Optional Ports for HTTP/HTTPS Services:** Modified the `is_valid_service` validation to make the port optional for `http://` and `https://` service targets (e.g., `http://my-service` is now valid). Cloudflare Tunnel will implicitly use the default ports (80 for HTTP, 443 for HTTPS) if none are specified.