### PR TITLE
feat: Add IP and Geolocation policy rules to Access Groups

### DIFF
--- a/dockflare/app/static/json/countries.json
+++ b/dockflare/app/static/json/countries.json
@@ -1,0 +1,982 @@
+[
+    {
+        "country": "Afghanistan",
+        "abbreviation": "AF"
+    },
+    {
+        "country": "Albania",
+        "abbreviation": "AL"
+    },
+    {
+        "country": "Algeria",
+        "abbreviation": "DZ"
+    },
+    {
+        "country": "American Samoa",
+        "abbreviation": "AS"
+    },
+    {
+        "country": "Andorra",
+        "abbreviation": "AD"
+    },
+    {
+        "country": "Angola",
+        "abbreviation": "AO"
+    },
+    {
+        "country": "Anguilla",
+        "abbreviation": "AI"
+    },
+    {
+        "country": "Antarctica",
+        "abbreviation": "AQ"
+    },
+    {
+        "country": "Antigua and Barbuda",
+        "abbreviation": "AG"
+    },
+    {
+        "country": "Argentina",
+        "abbreviation": "AR"
+    },
+    {
+        "country": "Armenia",
+        "abbreviation": "AM"
+    },
+    {
+        "country": "Aruba",
+        "abbreviation": "AW"
+    },
+    {
+        "country": "Australia",
+        "abbreviation": "AU"
+    },
+    {
+        "country": "Austria",
+        "abbreviation": "AT"
+    },
+    {
+        "country": "Azerbaijan",
+        "abbreviation": "AZ"
+    },
+    {
+        "country": "Bahamas",
+        "abbreviation": "BS"
+    },
+    {
+        "country": "Bahrain",
+        "abbreviation": "BH"
+    },
+    {
+        "country": "Bangladesh",
+        "abbreviation": "BD"
+    },
+    {
+        "country": "Barbados",
+        "abbreviation": "BB"
+    },
+    {
+        "country": "Belarus",
+        "abbreviation": "BY"
+    },
+    {
+        "country": "Belgium",
+        "abbreviation": "BE"
+    },
+    {
+        "country": "Belize",
+        "abbreviation": "BZ"
+    },
+    {
+        "country": "Benin",
+        "abbreviation": "BJ"
+    },
+    {
+        "country": "Bermuda",
+        "abbreviation": "BM"
+    },
+    {
+        "country": "Bhutan",
+        "abbreviation": "BT"
+    },
+    {
+        "country": "Bolivia",
+        "abbreviation": "BO"
+    },
+    {
+        "country": "Bosnia and Herzegovina",
+        "abbreviation": "BA"
+    },
+    {
+        "country": "Botswana",
+        "abbreviation": "BW"
+    },
+    {
+        "country": "Bouvet Island",
+        "abbreviation": "BV"
+    },
+    {
+        "country": "Brazil",
+        "abbreviation": "BR"
+    },
+    {
+        "country": "British Indian Ocean Territory",
+        "abbreviation": "IO"
+    },
+    {
+        "country": "Brunei",
+        "abbreviation": "BN"
+    },
+    {
+        "country": "Bulgaria",
+        "abbreviation": "BG"
+    },
+    {
+        "country": "Burkina Faso",
+        "abbreviation": "BF"
+    },
+    {
+        "country": "Burundi",
+        "abbreviation": "BI"
+    },
+    {
+        "country": "Cambodia",
+        "abbreviation": "KH"
+    },
+    {
+        "country": "Cameroon",
+        "abbreviation": "CM"
+    },
+    {
+        "country": "Canada",
+        "abbreviation": "CA"
+    },
+    {
+        "country": "Cape Verde",
+        "abbreviation": "CV"
+    },
+    {
+        "country": "Cayman Islands",
+        "abbreviation": "KY"
+    },
+    {
+        "country": "Central African Republic",
+        "abbreviation": "CF"
+    },
+    {
+        "country": "Chad",
+        "abbreviation": "TD"
+    },
+    {
+        "country": "Chile",
+        "abbreviation": "CL"
+    },
+    {
+        "country": "China",
+        "abbreviation": "CN"
+    },
+    {
+        "country": "Christmas Island",
+        "abbreviation": "CX"
+    },
+    {
+        "country": "Cocos (Keeling) Islands",
+        "abbreviation": "CC"
+    },
+    {
+        "country": "Colombia",
+        "abbreviation": "CO"
+    },
+    {
+        "country": "Comoros",
+        "abbreviation": "KM"
+    },
+    {
+        "country": "Congo",
+        "abbreviation": "CG"
+    },
+    {
+        "country": "Cook Islands",
+        "abbreviation": "CK"
+    },
+    {
+        "country": "Costa Rica",
+        "abbreviation": "CR"
+    },
+    {
+        "country": "Croatia",
+        "abbreviation": "HR"
+    },
+    {
+        "country": "Cuba",
+        "abbreviation": "CU"
+    },
+    {
+        "country": "Cyprus",
+        "abbreviation": "CY"
+    },
+    {
+        "country": "Czech Republic",
+        "abbreviation": "CZ"
+    },
+    {
+        "country": "Denmark",
+        "abbreviation": "DK"
+    },
+    {
+        "country": "Djibouti",
+        "abbreviation": "DJ"
+    },
+    {
+        "country": "Dominica",
+        "abbreviation": "DM"
+    },
+    {
+        "country": "Dominican Republic",
+        "abbreviation": "DO"
+    },
+    {
+        "country": "East Timor",
+        "abbreviation": "TP"
+    },
+    {
+        "country": "Ecuador",
+        "abbreviation": "EC"
+    },
+    {
+        "country": "Egypt",
+        "abbreviation": "EG"
+    },
+    {
+        "country": "El Salvador",
+        "abbreviation": "SV"
+    },
+    {
+        "country": "Equatorial Guinea",
+        "abbreviation": "GQ"
+    },
+    {
+        "country": "Eritrea",
+        "abbreviation": "ER"
+    },
+    {
+        "country": "Estonia",
+        "abbreviation": "EE"
+    },
+    {
+        "country": "Eswatini",
+        "abbreviation": "SZ"
+    },
+    {
+        "country": "Ethiopia",
+        "abbreviation": "ET"
+    },
+    {
+        "country": "Falkland Islands",
+        "abbreviation": "FK"
+    },
+    {
+        "country": "Faroe Islands",
+        "abbreviation": "FO"
+    },
+    {
+        "country": "Fiji Islands",
+        "abbreviation": "FJ"
+    },
+    {
+        "country": "Finland",
+        "abbreviation": "FI"
+    },
+    {
+        "country": "France",
+        "abbreviation": "FR"
+    },
+    {
+        "country": "French Guiana",
+        "abbreviation": "GF"
+    },
+    {
+        "country": "French Polynesia",
+        "abbreviation": "PF"
+    },
+    {
+        "country": "French Southern territories",
+        "abbreviation": "TF"
+    },
+    {
+        "country": "Gabon",
+        "abbreviation": "GA"
+    },
+    {
+        "country": "Gambia",
+        "abbreviation": "GM"
+    },
+    {
+        "country": "Georgia",
+        "abbreviation": "GE"
+    },
+    {
+        "country": "Germany",
+        "abbreviation": "DE"
+    },
+    {
+        "country": "Ghana",
+        "abbreviation": "GH"
+    },
+    {
+        "country": "Gibraltar",
+        "abbreviation": "GI"
+    },
+    {
+        "country": "Greece",
+        "abbreviation": "GR"
+    },
+    {
+        "country": "Greenland",
+        "abbreviation": "GL"
+    },
+    {
+        "country": "Grenada",
+        "abbreviation": "GD"
+    },
+    {
+        "country": "Guadeloupe",
+        "abbreviation": "GP"
+    },
+    {
+        "country": "Guam",
+        "abbreviation": "GU"
+    },
+    {
+        "country": "Guatemala",
+        "abbreviation": "GT"
+    },
+    {
+        "country": "Guernsey",
+        "abbreviation": "GG"
+    },
+    {
+        "country": "Guinea",
+        "abbreviation": "GN"
+    },
+    {
+        "country": "Guinea-Bissau",
+        "abbreviation": "GW"
+    },
+    {
+        "country": "Guyana",
+        "abbreviation": "GY"
+    },
+    {
+        "country": "Haiti",
+        "abbreviation": "HT"
+    },
+    {
+        "country": "Heard Island and McDonald Islands",
+        "abbreviation": "HM"
+    },
+    {
+        "country": "Holy See (Vatican City State)",
+        "abbreviation": "VA"
+    },
+    {
+        "country": "Honduras",
+        "abbreviation": "HN"
+    },
+    {
+        "country": "Hong Kong",
+        "abbreviation": "HK"
+    },
+    {
+        "country": "Hungary",
+        "abbreviation": "HU"
+    },
+    {
+        "country": "Iceland",
+        "abbreviation": "IS"
+    },
+    {
+        "country": "India",
+        "abbreviation": "IN"
+    },
+    {
+        "country": "Indonesia",
+        "abbreviation": "ID"
+    },
+    {
+        "country": "Iran",
+        "abbreviation": "IR"
+    },
+    {
+        "country": "Iraq",
+        "abbreviation": "IQ"
+    },
+    {
+        "country": "Ireland",
+        "abbreviation": "IE"
+    },
+    {
+        "country": "Isle of Man",
+        "abbreviation": "IM"
+    },
+    {
+        "country": "Israel",
+        "abbreviation": "IL"
+    },
+    {
+        "country": "Italy",
+        "abbreviation": "IT"
+    },
+    {
+        "country": "Ivory Coast",
+        "abbreviation": "CI"
+    },
+    {
+        "country": "Jamaica",
+        "abbreviation": "JM"
+    },
+    {
+        "country": "Japan",
+        "abbreviation": "JP"
+    },
+    {
+        "country": "Jersey",
+        "abbreviation": "JE"
+    },
+    {
+        "country": "Jordan",
+        "abbreviation": "JO"
+    },
+    {
+        "country": "Kazakhstan",
+        "abbreviation": "KZ"
+    },
+    {
+        "country": "Kenya",
+        "abbreviation": "KE"
+    },
+    {
+        "country": "Kiribati",
+        "abbreviation": "KI"
+    },
+    {
+        "country": "Kuwait",
+        "abbreviation": "KW"
+    },
+    {
+        "country": "Kyrgyzstan",
+        "abbreviation": "KG"
+    },
+    {
+        "country": "Laos",
+        "abbreviation": "LA"
+    },
+    {
+        "country": "Latvia",
+        "abbreviation": "LV"
+    },
+    {
+        "country": "Lebanon",
+        "abbreviation": "LB"
+    },
+    {
+        "country": "Lesotho",
+        "abbreviation": "LS"
+    },
+    {
+        "country": "Liberia",
+        "abbreviation": "LR"
+    },
+    {
+        "country": "Libya",
+        "abbreviation": "LY"
+    },
+    {
+        "country": "Liechtenstein",
+        "abbreviation": "LI"
+    },
+    {
+        "country": "Lithuania",
+        "abbreviation": "LT"
+    },
+    {
+        "country": "Luxembourg",
+        "abbreviation": "LU"
+    },
+    {
+        "country": "Macao",
+        "abbreviation": "MO"
+    },
+    {
+        "country": "North Macedonia",
+        "abbreviation": "MK"
+    },
+    {
+        "country": "Madagascar",
+        "abbreviation": "MG"
+    },
+    {
+        "country": "Malawi",
+        "abbreviation": "MW"
+    },
+    {
+        "country": "Malaysia",
+        "abbreviation": "MY"
+    },
+    {
+        "country": "Maldives",
+        "abbreviation": "MV"
+    },
+    {
+        "country": "Mali",
+        "abbreviation": "ML"
+    },
+    {
+        "country": "Malta",
+        "abbreviation": "MT"
+    },
+    {
+        "country": "Marshall Islands",
+        "abbreviation": "MH"
+    },
+    {
+        "country": "Martinique",
+        "abbreviation": "MQ"
+    },
+    {
+        "country": "Mauritania",
+        "abbreviation": "MR"
+    },
+    {
+        "country": "Mauritius",
+        "abbreviation": "MU"
+    },
+    {
+        "country": "Mayotte",
+        "abbreviation": "YT"
+    },
+    {
+        "country": "Mexico",
+        "abbreviation": "MX"
+    },
+    {
+        "country": "Micronesia, Federated States of",
+        "abbreviation": "FM"
+    },
+    {
+        "country": "Moldova",
+        "abbreviation": "MD"
+    },
+    {
+        "country": "Monaco",
+        "abbreviation": "MC"
+    },
+    {
+        "country": "Mongolia",
+        "abbreviation": "MN"
+    },
+    {
+        "country": "Montenegro",
+        "abbreviation": "ME"
+    },
+    {
+        "country": "Montserrat",
+        "abbreviation": "MS"
+    },
+    {
+        "country": "Morocco",
+        "abbreviation": "MA"
+    },
+    {
+        "country": "Mozambique",
+        "abbreviation": "MZ"
+    },
+    {
+        "country": "Myanmar",
+        "abbreviation": "MM"
+    },
+    {
+        "country": "Namibia",
+        "abbreviation": "NA"
+    },
+    {
+        "country": "Nauru",
+        "abbreviation": "NR"
+    },
+    {
+        "country": "Nepal",
+        "abbreviation": "NP"
+    },
+    {
+        "country": "Netherlands",
+        "abbreviation": "NL"
+    },
+    {
+        "country": "Netherlands Antilles",
+        "abbreviation": "AN"
+    },
+    {
+        "country": "New Caledonia",
+        "abbreviation": "NC"
+    },
+    {
+        "country": "New Zealand",
+        "abbreviation": "NZ"
+    },
+    {
+        "country": "Nicaragua",
+        "abbreviation": "NI"
+    },
+    {
+        "country": "Niger",
+        "abbreviation": "NE"
+    },
+    {
+        "country": "Nigeria",
+        "abbreviation": "NG"
+    },
+    {
+        "country": "Niue",
+        "abbreviation": "NU"
+    },
+    {
+        "country": "Norfolk Island",
+        "abbreviation": "NF"
+    },
+    {
+        "country": "North Korea",
+        "abbreviation": "KP"
+    },
+    {
+        "country": "Northern Ireland",
+        "abbreviation": "GB"
+    },
+    {
+        "country": "Northern Mariana Islands",
+        "abbreviation": "MP"
+    },
+    {
+        "country": "Norway",
+        "abbreviation": "NO"
+    },
+    {
+        "country": "Oman",
+        "abbreviation": "OM"
+    },
+    {
+        "country": "Pakistan",
+        "abbreviation": "PK"
+    },
+    {
+        "country": "Palau",
+        "abbreviation": "PW"
+    },
+    {
+        "country": "Palestine",
+        "abbreviation": "PS"
+    },
+    {
+        "country": "Panama",
+        "abbreviation": "PA"
+    },
+    {
+        "country": "Papua New Guinea",
+        "abbreviation": "PG"
+    },
+    {
+        "country": "Paraguay",
+        "abbreviation": "PY"
+    },
+    {
+        "country": "Peru",
+        "abbreviation": "PE"
+    },
+    {
+        "country": "Philippines",
+        "abbreviation": "PH"
+    },
+    {
+        "country": "Pitcairn",
+        "abbreviation": "PN"
+    },
+    {
+        "country": "Poland",
+        "abbreviation": "PL"
+    },
+    {
+        "country": "Portugal",
+        "abbreviation": "PT"
+    },
+    {
+        "country": "Puerto Rico",
+        "abbreviation": "PR"
+    },
+    {
+        "country": "Qatar",
+        "abbreviation": "QA"
+    },
+    {
+        "country": "Reunion",
+        "abbreviation": "RE"
+    },
+    {
+        "country": "Romania",
+        "abbreviation": "RO"
+    },
+    {
+        "country": "Russia",
+        "abbreviation": "RU"
+    },
+    {
+        "country": "Rwanda",
+        "abbreviation": "RW"
+    },
+    {
+        "country": "Saint Helena",
+        "abbreviation": "SH"
+    },
+    {
+        "country": "Saint Kitts and Nevis",
+        "abbreviation": "KN"
+    },
+    {
+        "country": "Saint Lucia",
+        "abbreviation": "LC"
+    },
+    {
+        "country": "Saint Pierre and Miquelon",
+        "abbreviation": "PM"
+    },
+    {
+        "country": "Saint Vincent and the Grenadines",
+        "abbreviation": "VC"
+    },
+    {
+        "country": "Samoa",
+        "abbreviation": "WS"
+    },
+    {
+        "country": "San Marino",
+        "abbreviation": "SM"
+    },
+    {
+        "country": "Sao Tome and Principe",
+        "abbreviation": "ST"
+    },
+    {
+        "country": "Saudi Arabia",
+        "abbreviation": "SA"
+    },
+    {
+        "country": "Senegal",
+        "abbreviation": "SN"
+    },
+    {
+        "country": "Serbia",
+        "abbreviation": "RS"
+    },
+    {
+        "country": "Seychelles",
+        "abbreviation": "SC"
+    },
+    {
+        "country": "Sierra Leone",
+        "abbreviation": "SL"
+    },
+    {
+        "country": "Singapore",
+        "abbreviation": "SG"
+    },
+    {
+        "country": "Slovakia",
+        "abbreviation": "SK"
+    },
+    {
+        "country": "Slovenia",
+        "abbreviation": "SI"
+    },
+    {
+        "country": "Solomon Islands",
+        "abbreviation": "SB"
+    },
+    {
+        "country": "Somalia",
+        "abbreviation": "SO"
+    },
+    {
+        "country": "South Africa",
+        "abbreviation": "ZA"
+    },
+    {
+        "country": "South Georgia and the South Sandwich Islands",
+        "abbreviation": "GS"
+    },
+    {
+        "country": "South Korea",
+        "abbreviation": "KR"
+    },
+    {
+        "country": "South Sudan",
+        "abbreviation": "SS"
+    },
+    {
+        "country": "Spain",
+        "abbreviation": "ES"
+    },
+    {
+        "country": "Sri Lanka",
+        "abbreviation": "LK"
+    },
+    {
+        "country": "Sudan",
+        "abbreviation": "SD"
+    },
+    {
+        "country": "Suriname",
+        "abbreviation": "SR"
+    },
+    {
+        "country": "Svalbard and Jan Mayen",
+        "abbreviation": "SJ"
+    },
+    {
+        "country": "Sweden",
+        "abbreviation": "SE"
+    },
+    {
+        "country": "Switzerland",
+        "abbreviation": "CH"
+    },
+    {
+        "country": "Syria",
+        "abbreviation": "SY"
+    },
+    {
+        "country": "Tajikistan",
+        "abbreviation": "TJ"
+    },
+    {
+        "country": "Tanzania",
+        "abbreviation": "TZ"
+    },
+    {
+        "country": "Thailand",
+        "abbreviation": "TH"
+    },
+    {
+        "country": "The Democratic Republic of Congo",
+        "abbreviation": "CD"
+    },
+    {
+        "country": "Timor-Leste",
+        "abbreviation": "TL"
+    },
+    {
+        "country": "Togo",
+        "abbreviation": "TG"
+    },
+    {
+        "country": "Tokelau",
+        "abbreviation": "TK"
+    },
+    {
+        "country": "Tonga",
+        "abbreviation": "TO"
+    },
+    {
+        "country": "Trinidad and Tobago",
+        "abbreviation": "TT"
+    },
+    {
+        "country": "Tunisia",
+        "abbreviation": "TN"
+    },
+    {
+        "country": "Turkey",
+        "abbreviation": "TR"
+    },
+    {
+        "country": "Turkmenistan",
+        "abbreviation": "TM"
+    },
+    {
+        "country": "Turks and Caicos Islands",
+        "abbreviation": "TC"
+    },
+    {
+        "country": "Tuvalu",
+        "abbreviation": "TV"
+    },
+    {
+        "country": "Uganda",
+        "abbreviation": "UG"
+    },
+    {
+        "country": "Ukraine",
+        "abbreviation": "UA"
+    },
+    {
+        "country": "United Arab Emirates",
+        "abbreviation": "AE"
+    },
+    {
+        "country": "United Kingdom",
+        "abbreviation": "UK"
+    },
+    {
+        "country": "United States",
+        "abbreviation": "US"
+    },
+    {
+        "country": "United States Minor Outlying Islands",
+        "abbreviation": "UM"
+    },
+    {
+        "country": "Uruguay",
+        "abbreviation": "UY"
+    },
+    {
+        "country": "Uzbekistan",
+        "abbreviation": "UZ"
+    },
+    {
+        "country": "Vanuatu",
+        "abbreviation": "VU"
+    },
+    {
+        "country": "Venezuela",
+        "abbreviation": "VE"
+    },
+    {
+        "country": "Vietnam",
+        "abbreviation": "VN"
+    },
+    {
+        "country": "Virgin Islands, British",
+        "abbreviation": "VG"
+    },
+    {
+        "country": "Virgin Islands, U.S.",
+        "abbreviation": "VI"
+    },
+    {
+        "country": "Wallis and Futuna",
+        "abbreviation": "WF"
+    },
+    {
+        "country": "Western Sahara",
+        "abbreviation": "EH"
+    },
+    {
+        "country": "Yemen",
+        "abbreviation": "YE"
+    },
+    {
+        "country": "Zambia",
+        "abbreviation": "ZM"
+    },
+    {
+        "country": "Zimbabwe",
+        "abbreviation": "ZW"
+    }
+]

--- a/dockflare/app/templates/base.html
+++ b/dockflare/app/templates/base.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/output.css') }}">
     <link rel="preconnect" href="https://rsms.me" crossorigin>
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/css/tom-select.css" rel="stylesheet">
     
     <style>
         body { font-family: system-ui, -apple-system, sans-serif; }
@@ -96,6 +97,8 @@
     
     {% block modals %}{% endblock %}
 
+    <script src="https://cdn.jsdelivr.net/npm/tom-select@2.2.2/dist/js/tom-select.complete.min.js"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/dockflare/app/templates/modals/_access_group_modal.html
+++ b/dockflare/app/templates/modals/_access_group_modal.html
@@ -29,6 +29,20 @@
                     <textarea id="group_emails" name="emails" class="textarea textarea-bordered h-24" placeholder="me@example.com, myfriend@example.com, @mycompany.com"></textarea>
                     <div class="label"><span class="label-text-alt">Comma-separated. To allow anyone from a domain, use <code class="text-xs">@domain.com</code>.</span></div>
                 </div>
+                <div class="form-control">
+                    <label class="label" for="group_ip_ranges"><span class="label-text">Allowed IP Ranges</span></label>
+                    <textarea id="group_ip_ranges" name="ip_ranges" class="textarea textarea-bordered h-24" placeholder="192.168.1.0/24, 2001:db8::/32"></textarea>
+                    <div class="label"><span class="label-text-alt">Comma-separated list of IP ranges in CIDR format.</span></div>
+                </div>
+                <div class="form-control">
+                    <label class="label" for="group_countries"><span class="label-text">Allowed Countries</span></label>
+                    <select id="group_countries" name="countries" multiple="multiple" class="input input-bordered w-full">
+                        {% for country in countries %}
+                            <option value="{{ country.abbreviation }}">{{ country.country }}</option>
+                        {% endfor %}
+                    </select>
+                    <div class="label"><span class="label-text-alt">Select one or more countries.</span></div>
+                </div>
             </div>
 
             <div>

--- a/dockflare/app/templates/settings.html
+++ b/dockflare/app/templates/settings.html
@@ -433,3 +433,58 @@
     {{ super() }}
     {% include 'modals/_access_group_modal.html' %}
 {% endblock %}
+
+{% block scripts %}
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var countrySelectInstance = null;
+
+        function initializeCountrySelect() {
+            if (countrySelectInstance) {
+                countrySelectInstance.destroy();
+            }
+            countrySelectInstance = new TomSelect('#group_countries', {
+                plugins: {
+                    'checkbox_options': {},
+                    'remove_button': {
+                        title: 'Remove this item',
+                    }
+                },
+                create: false,
+                sortField: {
+                    field: "text",
+                    direction: "asc"
+                }
+            });
+        }
+
+        // Handle opening the modal for editing
+        document.querySelectorAll('.edit-access-group-btn').forEach(button => {
+            button.addEventListener('click', function() {
+                setTimeout(() => { // Allow modal to become visible
+                    initializeCountrySelect();
+                    const details = JSON.parse(this.dataset.groupDetails);
+                    if (details.policies) {
+                        const countryCodes = details.policies
+                            .flatMap(p => p.include || [])
+                            .filter(i => i.geo && i.geo.country_code)
+                            .map(i => i.geo.country_code);
+                        countrySelectInstance.setValue(countryCodes);
+                    }
+                }, 100);
+            });
+        });
+
+        // Handle opening the modal for creating
+        const createBtn = document.querySelector('button[onclick="openCreateAccessGroupModal()"]');
+        if (createBtn) {
+            createBtn.addEventListener('click', function() {
+                setTimeout(() => { // Allow modal to become visible
+                    initializeCountrySelect();
+                    countrySelectInstance.clear();
+                }, 100);
+            });
+        }
+    });
+</script>
+{% endblock %}

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -395,6 +395,14 @@ def settings_page():
     all_account_tunnels_list = get_all_account_cloudflare_tunnels()
     cf_account_id = current_app.config.get('CF_ACCOUNT_ID')
 
+    try:
+        with open(os.path.join(current_app.static_folder, 'json', 'countries.json')) as f:
+            countries = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        countries = []
+        flash('Could not load country list for Access Group modal.', 'error')
+
+
     return render_template(
         'settings.html',
         settings_form=settings_form,
@@ -404,6 +412,7 @@ def settings_page():
         access_groups=groups_for_template,
         used_group_ids=used_group_ids,
         all_account_tunnels=all_account_tunnels_list,
+        countries=countries,
         tunnel_state=template_tunnel_state,
         agent_state=template_agent_state,
         display_token=display_token_val,
@@ -1074,24 +1083,31 @@ def ui_edit_manual_rule_route():
 
     return redirect(url_for('web.status_page'))
 
-def _parse_and_build_policy_from_form(email_str):
-    if not email_str or not email_str.strip():
-        return []
-    
+def _parse_and_build_policy_from_form(email_str, ip_ranges_str=None, countries_list=None):
     include_rules = []
-    
-    parts = [part.strip() for part in email_str.split(',') if part.strip()]
-    for part in parts:
-        if part.startswith('@'):
-            include_rules.append({"email_domain": {"domain": part[1:]}})
-        else:
-            include_rules.append({"email": {"email": part}})
+
+    if email_str and email_str.strip():
+        email_parts = [part.strip() for part in email_str.split(',') if part.strip()]
+        for part in email_parts:
+            if part.startswith('@'):
+                include_rules.append({"email_domain": {"domain": part[1:]}})
+            else:
+                include_rules.append({"email": {"email": part}})
+
+    if ip_ranges_str and ip_ranges_str.strip():
+        ip_parts = [part.strip() for part in ip_ranges_str.split(',') if part.strip()]
+        for ip in ip_parts:
+            include_rules.append({"ip": {"ip": ip}})
+
+    if countries_list:
+        for country in countries_list:
+            include_rules.append({"geo": {"country_code": country}})
             
     if not include_rules:
         return []
 
     return [
-        {"name": "Allow defined users and domains", "decision": "allow", "include": include_rules},
+        {"name": "Allow defined users, domains, IPs, and countries", "decision": "allow", "include": include_rules},
         {"name": "Default Deny", "decision": "deny", "include": [{"everyone": {}}]}
     ]
 
@@ -1117,7 +1133,11 @@ def create_access_group():
             "session_duration": form.get('session_duration', '24h').strip(),
             "app_launcher_visible": form.get('app_launcher_visible') == 'on',
             "auto_redirect_to_identity": form.get('auto_redirect') == 'on',
-            "policies": _parse_and_build_policy_from_form(form.get('emails', ''))
+            "policies": _parse_and_build_policy_from_form(
+                form.get('emails', ''),
+                form.get('ip_ranges', ''),
+                request.form.getlist('countries')
+            )
         }
         access_groups[group_id] = new_group
         save_state()
@@ -1146,7 +1166,11 @@ def edit_access_group(group_id):
             "session_duration": form.get('session_duration', '24h').strip(),
             "app_launcher_visible": form.get('app_launcher_visible') == 'on',
             "auto_redirect_to_identity": form.get('auto_redirect') == 'on',
-            "policies": _parse_and_build_policy_from_form(form.get('emails', ''))
+            "policies": _parse_and_build_policy_from_form(
+                form.get('emails', ''),
+                form.get('ip_ranges', ''),
+                request.form.getlist('countries')
+            )
         }
         access_groups[group_id] = updated_group
         save_state()


### PR DESCRIPTION
This commit enhances the Access Group feature by allowing users to define policy rules based on IP ranges and geographic locations.

Key changes:
- Adds new fields to the Access Group modal for "Allowed IP Ranges" and "Allowed Countries".
- Implements a user-friendly multi-select dropdown with search and checkboxes for country selection, powered by the Tom Select library.
- Adds a `countries.json` file to populate the country selector.
- Updates the backend logic in `routes.py` to parse the new IP and country data and construct the corresponding Cloudflare Access Policy rules.
- Handles both creation and editing of Access Groups with these new policy types.

Fixes:
- Updates the Content Security Policy (CSP) to include `cdn.jsdelivr.net` in the `script-src` and `style-src` directives, allowing the Tom Select library to be loaded from the CDN.