### PR TITLE
Add support for host-gateway via dns in cloudflared container

### DIFF
--- a/dockflare/app/core/tunnel_manager.py
+++ b/dockflare/app/core/tunnel_manager.py
@@ -569,7 +569,8 @@ def start_cloudflared_container():
                     "detach": True,
                     "remove": False, 
                     "labels": {"managed-by": "dockflare"},
-                    "ports": ports_mapping 
+                    "ports": ports_mapping,
+                    "extra_hosts": {"host.docker.internal": "host-gateway"},
                 }
                 new_container = docker_client.containers.run(**container_params)
                 msg = f"Successfully created and started agent container '{new_container.name}' ({new_container.id[:12]})."


### PR DESCRIPTION
I wanted an easy way to add my docker host into DockFlare without having to reference by IP, for a couple of reasons:
* Not everyone knows how to find the docker host IP (172.17.0.1) manually.
* Referencing the local network IP (192.168.0.x) doesn't work when changing networks often (home, work, travelling, etc)

Now in the UI of dockflare, you can simply use `host.docker.internal` as a service URL and it will always point to the docker Host machine.

<img width="230" height="112" alt="image" src="https://github.com/user-attachments/assets/76330eab-c78c-41d1-afa8-cebd03c7c72a" />

I guess it would be nice to have this as a configurable setting within DockFlare to change the `host.docker.internal` string to be something else, but this simple patch works enough for me.