### PR TITLE
feat(tunnels): add tunnel deletion functionality via API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.8'
 services:
   dockflare:
-    image: alplat/dockflare:stable  # alplat/dockflare:unstable docker tag for beta versions
-    # build: ./dockflare  # Uncomment to build from source instead
+    # image: alplat/dockflare:stable  # alplat/dockflare:unstable docker tag for beta versions
+    build: ./dockflare  # Uncomment to build from source instead
     container_name: dockflare
     restart: unless-stopped
     ports:
@@ -14,7 +14,7 @@ services:
       - cloudflare-net  # Network for communication with other containers
     environment:
       - STATE_FILE_PATH=/app/data/state.json
-      - TZ=Europe/Zurich  # Set your timezone here
+      - TZ=America/Sao_Paulo  # Set your timezone here
     #labels: # Optional
     #- dockflare.enable=true
     #- dockflare.hostname=dockflare.yourdomain.tld

--- a/dockflare/app/core/cloudflare_api.py
+++ b/dockflare/app/core/cloudflare_api.py
@@ -589,6 +589,23 @@ def get_all_account_cloudflare_tunnels():
     filtered_tunnels.sort(key=lambda t: t.get("name", "").lower()) 
     return filtered_tunnels
 
+
+def delete_tunnel_via_api(tunnel_id):
+    account_id = current_app.config.get('CF_ACCOUNT_ID')
+    logging.info(f"Deleting tunnel ID '{tunnel_id}' via API on account {account_id}")
+    endpoint = f"/accounts/{account_id}/cfd_tunnel/{tunnel_id}"
+    try:
+        cf_api_request("DELETE", endpoint)
+        logging.info(f"Successfully deleted tunnel ID '{tunnel_id}'.")
+        return True
+    except requests.exceptions.RequestException as e:
+        logging.error(f"API error deleting tunnel '{tunnel_id}': {e}")
+        raise
+    except Exception as e:
+        logging.error(f"Unexpected error deleting tunnel '{tunnel_id}': {e}", exc_info=True)
+        raise
+
+
 def get_dns_records_for_tunnel(zone_id, tunnel_id):
     if not zone_id or not tunnel_id:
         logging.warning("get_dns_records_for_tunnel: Missing zone_id or tunnel_id.")

--- a/dockflare/app/templates/settings.html
+++ b/dockflare/app/templates/settings.html
@@ -150,6 +150,7 @@
                                         <th>Status</th>
                                         <th>Created At</th>
                                         <th>Connections</th>
+                                        <th>Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -175,9 +176,16 @@
                                                     {% if tunnel.connections | length > 0 %}({{ tunnel.connections | length }} total){% else %}(0 total){% endif %}
                                                 {% elif tunnel.connections %}{{ tunnel.connections | e }}{% else %}None{% endif %}
                                             </td>
+                                            <td>
+                                                <button class="btn btn-xs btn-error" 
+                                                        onclick="confirmDelete('{{ tunnel.id }}', '{{ tunnel.name }}')"
+                                                        {% if tunnel.id == dockflare_tunnel_id %}disabled{% endif %}>
+                                                    Delete
+                                                </button>
+                                            </td>
                                         </tr>
                                         <tr class="dns-records-row hidden bg-base-200/30">
-                                            <td colspan="6">
+                                            <td colspan="7">
                                                 <div id="dns-records-{{ tunnel.id | e }}" class="p-4 text-sm space-y-2">
                                                     <p class="opacity-60 italic">Click the '+' button to load DNS records for this tunnel.</p>
                                                 </div>
@@ -527,4 +535,44 @@
   }
 })();
 </script>
+
+<script>
+    function confirmDelete(tunnelId, tunnelName) {
+        if (confirm(`Are you sure you want to delete the tunnel "${tunnelName}"? This action cannot be undone.`)) {
+            fetch(`/api/v2/tunnels/${tunnelId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+            .then(response => response.json().then(data => ({status: response.status, body: data})))
+            .then(({status, body}) => {
+                if (status === 200) {
+                    showToast(body.message, 'success');
+                    setTimeout(() => location.reload(), 2000);
+                } else {
+                    showToast(`Error: ${body.error}`, 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                showToast('An unexpected error occurred.', 'error');
+            });
+        }
+    }
+
+    function showToast(message, type = 'info') {
+        const toastContainer = document.getElementById('toast-container');
+        const toast = document.createElement('div');
+        toast.className = `alert alert-${type}`;
+        toast.innerHTML = `<span>${message}</span>`;
+        toastContainer.appendChild(toast);
+        setTimeout(() => {
+            toast.remove();
+        }, 5000);
+    }
+</script>
+
+<div id="toast-container" class="toast toast-top toast-end"></div>
+
 {% endblock %}

--- a/dockflare/app/web/api_v2_routes.py
+++ b/dockflare/app/web/api_v2_routes.py
@@ -36,6 +36,7 @@ from app.core.cloudflare_api import (
     get_dns_records_for_tunnel,
     create_cloudflare_dns_record,
     delete_cloudflare_dns_record,
+    delete_tunnel_via_api,
     get_zone_id_from_name,
     get_zone_details_by_id
 )
@@ -711,6 +712,24 @@ def revert_rule_access_policy_to_labels(rule_key):
 def get_account_tunnels_api():
     tunnels = get_all_account_cloudflare_tunnels()
     return jsonify({"tunnels": tunnels})
+
+
+@api_v2_bp.route('/tunnels/<tunnel_id>', methods=['DELETE'])
+def delete_tunnel_api(tunnel_id):
+    if not tunnel_id:
+        return jsonify({"error": "Tunnel ID is required"}), 400
+
+    dockflare_tunnel_id = tunnel_state.get("id")
+    if tunnel_id == dockflare_tunnel_id:
+        return jsonify({"error": "Cannot delete the primary DockFlare-managed tunnel."}), 403
+
+    try:
+        delete_tunnel_via_api(tunnel_id)
+        return jsonify({"message": f"Tunnel {tunnel_id} deleted successfully."}), 200
+    except Exception as e:
+        logging.error(f"Error deleting tunnel {tunnel_id}: {e}", exc_info=True)
+        return jsonify({"error": f"Failed to delete tunnel: {e}"}), 500
+
 
 @api_v2_bp.route('/tunnels/<tunnel_id>/dns-records', methods=['GET'])
 def get_tunnel_dns_records_api(tunnel_id):

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -472,7 +472,8 @@ def settings_page():
         external_cloudflared=config.USE_EXTERNAL_CLOUDFLARED,
         external_tunnel_id=config.EXTERNAL_TUNNEL_ID,
         CF_ACCOUNT_ID_CONFIGURED=bool(cf_account_id),
-        ACCOUNT_ID_FOR_DISPLAY=cf_account_id if cf_account_id else "Not Configured"
+        ACCOUNT_ID_FOR_DISPLAY=cf_account_id if cf_account_id else "Not Configured",
+        dockflare_tunnel_id=template_tunnel_state.get("id")
     )
 
 @bp.route('/change-password', methods=['POST'])


### PR DESCRIPTION
- Implement API endpoint for deleting Cloudflare tunnels
- Add delete button in settings UI with confirmation dialog
- Prevent deletion of primary DockFlare-managed tunnel
- Add toast notifications for operation feedback

<img width="1086" height="335" alt="image" src="https://github.com/user-attachments/assets/ba93559e-7711-4307-abba-8f624396b84b" />


