### PR TITLE
github action to selfhost runner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The actions runner for Docker images is now hosted on a self-hosted server, which allows for faster image building and the avoidance of any GitHub runner bottlenecks. 