### PR TITLE
Hotfixes v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v3.0.3] - 2025-10-05
 
+### Hotfix
+- **Access Policy Path Regression:** Restored indexed label support for Cloudflare Access applications so path-specific rules (e.g., `dockflare.0.path=/auth/google/callback`) once again create distinct Access Apps linked to their reusable policies. Fixes broken policy sync introduced with the reusable policy migration in v3.0.3.
+
 ### Added
 - **Identity Provider (IdP) Management:** Complete OAuth/OIDC identity provider management system with support for Google, Google Workspace, Azure AD, Okta, GitHub, and generic OpenID Connect providers.
   - **IdP Configuration UI:** New dedicated section on Access Policies page for managing identity providers with sync, create, edit, test, and delete operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Hotfix
 - **Access Policy Path Regression:** Restored indexed label support for Cloudflare Access applications so path-specific rules (e.g., `dockflare.0.path=/auth/google/callback`) once again create distinct Access Apps linked to their reusable policies. Fixes broken policy sync introduced with the reusable policy migration in v3.0.3.
+- **Access Policy Usage Display:** Corrected the “Used by these services” list so manual rules assigned to an Access Group appear alongside Docker/Agent-managed services, with paths shown when applicable.
 
 ### Added
 - **Identity Provider (IdP) Management:** Complete OAuth/OIDC identity provider management system with support for Google, Google Workspace, Azure AD, Okta, GitHub, and generic OpenID Connect providers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,20 +38,20 @@ services:
     restart: unless-stopped
     ports:
       - "5000:5000"
-    #labels:
+    labels:
       # -- Cloudflare Tunnel Configuration (via DockFlare) OPTIONAL --
       # Main DockFlare interface with access policy
       #- dockflare.enable=true
-      #- dockflare.hostname=dockflare.example.com
+      #- dockflare.hostname=dockflare.master.tld
       #- dockflare.service=http://dockflare:5000
-      #- dockflare.access.group=team  # your custom access policy
+      #- dockflare.access.group=YOUR-ACCESS-GROUP-ID  # your custom access policy
 
       # -- OAuth Callback Path (Bypass Access Policy) OPTIONAL --
       # Required if using OAuth authentication with access policies on main interface
-      # - dockflare.0.hostname=dockflare.example.com
-      # - dockflare.0.path=/auth/google/callback
-      # - dockflare.0.service=http://dockflare:5000
-      # - dockflare.0.access.policy=bypass
+      #- dockflare.0.hostname=dockflare.example.tld
+      #- dockflare.0.path=/auth/google/callback
+      #- dockflare.0.service=http://dockflare:5000
+      #- dockflare.0.access.group=public-default-bypass
 
       # Add additional callback paths for other OAuth providers as needed
       # - dockflare.1.hostname=dockflare.example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,14 +57,14 @@ services:
       # - dockflare.1.hostname=dockflare.example.com
       # - dockflare.1.path=/auth/github/callback
       # - dockflare.1.service=http://dockflare:5000
-      # - dockflare.1.access.policy=bypass
+      # - dockflare.1.access.group=public-default-bypass
     volumes:
       - dockflare_data:/app/data
     environment:
       - REDIS_URL=redis://redis:6379/0
       - REDIS_DB_INDEX=0  # Optional: specify Redis database index (0-15) for isolation from other containers
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
-      - LOG_LEVEL=DEBUG
+      # - LOG_LEVEL=DEBUG # Uncomment for more verbose logging/debugging
     depends_on:
       docker-socket-proxy:
         condition: service_started

--- a/dockflare/app/core/access_manager.py
+++ b/dockflare/app/core/access_manager.py
@@ -24,17 +24,18 @@ import copy
 from flask import current_app
 from app.core import cloudflare_api
 from app.core.state_manager import access_groups, managed_rules, state_lock
+from app.core.utils import normalize_path_value
 
 _ACCOUNT_EMAIL_CACHE_TTL = 3600
 _cached_account_email = None
 _cached_account_email_timestamp = 0
 
-def _build_access_app_payload(hostname, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies_or_ids, allowed_idps=None, auto_redirect_to_identity=False, use_reusable=False):
+def _build_access_app_payload(application_domain, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies_or_ids, allowed_idps=None, auto_redirect_to_identity=False, use_reusable=False):
     from app import config
 
     payload = {
         "name": name,
-        "domain": hostname,
+        "domain": application_domain,
         "type": "self_hosted",
         "session_duration": session_duration,
         "app_launcher_visible": app_launcher_visible,
@@ -76,7 +77,7 @@ def check_for_tld_access_policy(zone_name):
     logging.info(f"Checking for existing Access Policy for wildcard TLD: {tld_hostname}")
 
     try:
-        # Optimized TLD check: only do domain-specific query, skip expensive full list scan
+        
         account_id = current_app.config.get('CF_ACCOUNT_ID')
         endpoint = f"/accounts/{account_id}/access/apps"
         from app.core import cloudflare_api
@@ -141,49 +142,49 @@ def get_cloudflare_account_email():
         logging.error(f"Unexpected error fetching Cloudflare account email: {e}", exc_info=True)
         return None
 
-def find_cloudflare_access_application_by_hostname(hostname):
+def find_cloudflare_access_application_by_domain(application_domain):
     account_id = current_app.config.get('CF_ACCOUNT_ID')
-    logging.info(f"Finding Cloudflare Access Application for hostname '{hostname}' on account {account_id}")
+    logging.info(f"Finding Cloudflare Access Application for domain '{application_domain}' on account {account_id}")
     endpoint = f"/accounts/{account_id}/access/apps"
     try:
-        response_data_direct = cloudflare_api.cf_api_request("GET", endpoint, params={"domain": hostname})
+        response_data_direct = cloudflare_api.cf_api_request("GET", endpoint, params={"domain": application_domain})
         apps_direct = response_data_direct.get("result", [])
         if apps_direct and isinstance(apps_direct, list):
             for app in apps_direct:
-                if app.get("domain") == hostname:
-                    logging.info(f"Found Access Application ID '{app.get('id')}' for hostname '{hostname}' via direct domain query.")
+                if app.get("domain") == application_domain:
+                    logging.info(f"Found Access Application ID '{app.get('id')}' for domain '{application_domain}' via direct domain query.")
                     return app
 
-        logging.info(f"No exact match for '{hostname}' via domain query. Falling back to listing all Access Applications.")
+        logging.info(f"No exact match for '{application_domain}' via domain query. Falling back to listing all Access Applications.")
 
         all_apps_response = cloudflare_api.cf_api_request("GET", endpoint, params={"per_page": 100})
         all_apps = all_apps_response.get("result", [])
         if all_apps and isinstance(all_apps, list):
             for app in all_apps:
-                if app.get("domain") == hostname:
-                    logging.info(f"Found Access Application ID '{app.get('id')}' for hostname '{hostname}' via full list scan (domain match).")
+                if app.get("domain") == application_domain:
+                    logging.info(f"Found Access Application ID '{app.get('id')}' for domain '{application_domain}' via full list scan (domain match).")
                     return app
-                if hostname in app.get("self_hosted_domains", []):
-                    logging.info(f"Found Access Application ID '{app.get('id')}' for hostname '{hostname}' (in self_hosted_domains) via full list scan.")
+                if application_domain in app.get("self_hosted_domains", []):
+                    logging.info(f"Found Access Application ID '{app.get('id')}' for domain '{application_domain}' (in self_hosted_domains) via full list scan.")
                     return app
 
-        logging.info(f"Access Application for hostname '{hostname}' not found after extensive search.")
+        logging.info(f"Access Application for domain '{application_domain}' not found after extensive search.")
         return None
     except requests.exceptions.RequestException as e:
-        logging.error(f"API error finding Cloudflare Access Application for '{hostname}': {e}")
+        logging.error(f"API error finding Cloudflare Access Application for '{application_domain}': {e}")
         return None
     except Exception as e:
-        logging.error(f"Unexpected error finding Cloudflare Access Application for '{hostname}': {e}", exc_info=True)
+        logging.error(f"Unexpected error finding Cloudflare Access Application for '{application_domain}': {e}", exc_info=True)
         return None
 
-def create_cloudflare_access_application(hostname, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps=None, auto_redirect_to_identity=False, use_reusable=False):
+def create_cloudflare_access_application(application_domain, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps=None, auto_redirect_to_identity=False, use_reusable=False):
     account_id = current_app.config.get('CF_ACCOUNT_ID')
-    logging.info(f"Creating Cloudflare Access Application for hostname '{hostname}' on account {account_id}")
+    logging.info(f"Creating Cloudflare Access Application for domain '{application_domain}' on account {account_id}")
     endpoint = f"/accounts/{account_id}/access/apps"
 
-    payload = _build_access_app_payload(hostname, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps, auto_redirect_to_identity, use_reusable)
+    payload = _build_access_app_payload(application_domain, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps, auto_redirect_to_identity, use_reusable)
 
-    logging.info(f"Access Application payload for '{hostname}': use_reusable={use_reusable}, has_policies={'policies' in payload}")
+    logging.info(f"Access Application payload for '{application_domain}': use_reusable={use_reusable}, has_policies={'policies' in payload}")
     if 'policies' in payload:
         if use_reusable:
             logging.info(f"Reusable policy IDs: {payload['policies']}")
@@ -194,16 +195,16 @@ def create_cloudflare_access_application(hostname, name, session_duration, app_l
         app_data = response_data.get("result")
         if app_data and app_data.get("id"):
             app_id = app_data.get('id')
-            logging.info(f"Successfully created Access Application '{app_id}' for '{hostname}'")
+            logging.info(f"Successfully created Access Application '{app_id}' for '{application_domain}'")
             return app_data
         else:
-            logging.error(f"Access Application creation for '{hostname}' API call successful but no ID in response: {app_data}")
+            logging.error(f"Access Application creation for '{application_domain}' API call successful but no ID in response: {app_data}")
             return None
     except requests.exceptions.RequestException as e:
-        logging.error(f"API error creating Access Application for '{hostname}': {e}")
+        logging.error(f"API error creating Access Application for '{application_domain}': {e}")
         return None
     except Exception as e:
-        logging.error(f"Unexpected error creating Access Application for '{hostname}': {e}", exc_info=True)
+        logging.error(f"Unexpected error creating Access Application for '{application_domain}': {e}", exc_info=True)
         return None
 
 def get_cloudflare_access_application(app_uuid):
@@ -233,14 +234,14 @@ def get_cloudflare_access_application(app_uuid):
         logging.error(f"Unexpected error getting Access Application '{app_uuid}': {e}", exc_info=True)
         return None
 
-def update_cloudflare_access_application(app_uuid, hostname, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps=None, auto_redirect_to_identity=False, use_reusable=False):
+def update_cloudflare_access_application(app_uuid, application_domain, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps=None, auto_redirect_to_identity=False, use_reusable=False):
     account_id = current_app.config.get('CF_ACCOUNT_ID')
-    logging.info(f"Updating Cloudflare Access Application ID '{app_uuid}' for hostname '{hostname}' on account {account_id}")
+    logging.info(f"Updating Cloudflare Access Application ID '{app_uuid}' for domain '{application_domain}' on account {account_id}")
     endpoint = f"/accounts/{account_id}/access/apps/{app_uuid}"
 
-    payload = _build_access_app_payload(hostname, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps, auto_redirect_to_identity, use_reusable)
+    payload = _build_access_app_payload(application_domain, name, session_duration, app_launcher_visible, self_hosted_domains, access_policies, allowed_idps, auto_redirect_to_identity, use_reusable)
 
-    logging.info(f"Access Application update payload for '{hostname}': use_reusable={use_reusable}, has_policies={'policies' in payload}")
+    logging.info(f"Access Application update payload for '{application_domain}': use_reusable={use_reusable}, has_policies={'policies' in payload}")
     if 'policies' in payload:
         if use_reusable:
             logging.info(f"Reusable policy IDs for update: {payload['policies']}")
@@ -251,7 +252,7 @@ def update_cloudflare_access_application(app_uuid, hostname, name, session_durat
         response_data = cloudflare_api.cf_api_request("PUT", endpoint, json_data=payload)
         app_data = response_data.get("result")
         if app_data and app_data.get("id"):
-            logging.info(f"Successfully updated Access Application '{app_data.get('id')}' for '{hostname}'")
+            logging.info(f"Successfully updated Access Application '{app_data.get('id')}' for '{application_domain}'")
             return app_data
         else:
             logging.error(f"Access Application update for '{app_uuid}' API call successful but no ID in response: {app_data}")
@@ -326,6 +327,14 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
         rule_working = copy.deepcopy(rule_reference)
 
     hostname = hostname_config_item["hostname"]
+    normalized_path = normalize_path_value(hostname_config_item.get("path"))
+    is_path_rule = bool(normalized_path)
+    application_domain = hostname if not is_path_rule else f"{hostname}{normalized_path}"
+
+    path_identifier = ""
+    if is_path_rule:
+        path_identifier = normalized_path.lstrip('/') or "root"
+        path_identifier = path_identifier.replace('/', '-').replace(' ', '-')
     local_state_changed_by_access_policy = False
 
     current_access_app_id_from_state = rule_working.get("access_app_id")
@@ -333,6 +342,8 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
     desired_access_group_ids = hostname_config_item.get("access_group")
 
     desired_app_name = f"DockFlare-{hostname}"
+    if path_identifier:
+        desired_app_name = f"{desired_app_name}-{path_identifier}"
     desired_session_duration = "24h"
     desired_app_launcher_visible = False
     desired_allowed_idps = None
@@ -343,7 +354,7 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
     use_reusable = False
 
     if desired_access_group_ids and isinstance(desired_access_group_ids, list):
-        logging.info(f"Processing Access Groups {desired_access_group_ids} for {hostname}.")
+        logging.info(f"Processing Access Groups {desired_access_group_ids} for {application_domain}.")
         policy_source_type = "group"
 
         first_group_id = desired_access_group_ids[0]
@@ -367,7 +378,7 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
                 if policy_id:
                     policy_ids.append(policy_id)
                 else:
-                    logging.warning(f"Failed to sync access group '{group_id}' to reusable policy for {hostname}")
+                    logging.warning(f"Failed to sync access group '{group_id}' to reusable policy for {application_domain}")
             cf_access_policies_or_ids = policy_ids
         else:
             aggregated_policies = []
@@ -405,7 +416,7 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
         policy_source_type = hostname_config_item.get("access_policy_type")
         if not policy_source_type:
             if current_access_app_id_from_state:
-                logging.info(f"No access policy label for {hostname}, but found managed Access App {current_access_app_id_from_state}. Deleting it.")
+                logging.info(f"No access policy label for {application_domain}, but found managed Access App {current_access_app_id_from_state}. Deleting it.")
                 if delete_cloudflare_access_application(current_access_app_id_from_state):
                     rule_working.update({"access_app_id": None, "access_policy_type": None, "access_app_config_hash": None, "access_group_id": None})
                     local_state_changed_by_access_policy = True
@@ -449,13 +460,13 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
             try:
                 cf_access_policies_or_ids = json.loads(desired_custom_rules_str)
             except json.JSONDecodeError:
-                logging.error(f"Error parsing 'custom_rules' JSON for {hostname}")
+                logging.error(f"Error parsing 'custom_rules' JSON for {application_domain}")
 
         if not cf_access_policies_or_ids:
             if policy_source_type == "bypass":
-                logging.warning(f"ACCESS_MANAGER: Unexpected 'bypass' policy type reached access_manager for {hostname}. This should have been migrated to access.group=bypass. Skipping access policy creation.")
+                logging.warning(f"ACCESS_MANAGER: Unexpected 'bypass' policy type reached access_manager for {application_domain}. This should have been migrated to access.group=bypass. Skipping access policy creation.")
                 if current_access_app_id_from_state:
-                    logging.info(f"Deleting existing Access App {current_access_app_id_from_state} for {hostname} since bypass should not have an access app.")
+                    logging.info(f"Deleting existing Access App {current_access_app_id_from_state} for {application_domain} since bypass should not have an access app.")
                     if delete_cloudflare_access_application(current_access_app_id_from_state):
                         rule_working.update({"access_app_id": None, "access_policy_type": None, "access_app_config_hash": None, "access_group_id": None})
                         local_state_changed_by_access_policy = True
@@ -466,9 +477,9 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
                             current_rule.update({"access_app_id": rule_working.get("access_app_id"), "access_policy_type": rule_working.get("access_policy_type"), "access_app_config_hash": rule_working.get("access_app_config_hash"), "access_group_id": rule_working.get("access_group_id")})
                 return local_state_changed_by_access_policy
             elif policy_source_type == "authenticate":
-                logging.warning(f"ACCESS_MANAGER: Unexpected 'authenticate' policy type reached access_manager for {hostname}. This should have been migrated to access.group=authenticated-default. Skipping access policy creation.")
+                logging.warning(f"ACCESS_MANAGER: Unexpected 'authenticate' policy type reached access_manager for {application_domain}. This should have been migrated to access.group=authenticated-default. Skipping access policy creation.")
                 if current_access_app_id_from_state:
-                    logging.info(f"Deleting existing Access App {current_access_app_id_from_state} for {hostname} since it should use authenticated-default group.")
+                    logging.info(f"Deleting existing Access App {current_access_app_id_from_state} for {application_domain} since it should use authenticated-default group.")
                     if delete_cloudflare_access_application(current_access_app_id_from_state):
                         rule_working.update({"access_app_id": None, "access_policy_type": None, "access_app_config_hash": None, "access_group_id": None})
                         local_state_changed_by_access_policy = True
@@ -489,26 +500,26 @@ def handle_access_policy_from_labels(rule_key, hostname_config_item):
     if needs_api_action:
         effective_app_id = rule_working.get("access_app_id")
         if not effective_app_id:
-            existing_cf_app = find_cloudflare_access_application_by_hostname(hostname)
+            existing_cf_app = find_cloudflare_access_application_by_domain(application_domain)
             if existing_cf_app and existing_cf_app.get("id"):
                 effective_app_id = existing_cf_app.get("id")
-                logging.info(f"Found existing Access App ID '{effective_app_id}' on Cloudflare for {hostname}. Will update.")
+                logging.info(f"Found existing Access App ID '{effective_app_id}' on Cloudflare for {application_domain}. Will update.")
                 rule_working["access_app_id"] = effective_app_id
                 local_state_changed_by_access_policy = True
 
         app_result = None
         if effective_app_id:
-            logging.info(f"Updating Access App {effective_app_id} for {hostname}.")
+            logging.info(f"Updating Access App {effective_app_id} for {application_domain}.")
             app_result = update_cloudflare_access_application(
-                effective_app_id, hostname, desired_app_name, desired_session_duration,
-                desired_app_launcher_visible, [hostname], cf_access_policies_or_ids,
+                effective_app_id, application_domain, desired_app_name, desired_session_duration,
+                desired_app_launcher_visible, [application_domain], cf_access_policies_or_ids,
                 desired_allowed_idps, desired_auto_redirect, use_reusable
             )
         else:
-            logging.info(f"Creating new Access App for {hostname}.")
+            logging.info(f"Creating new Access App for {application_domain}.")
             app_result = create_cloudflare_access_application(
-                hostname, desired_app_name, desired_session_duration,
-                desired_app_launcher_visible, [hostname], cf_access_policies_or_ids,
+                application_domain, desired_app_name, desired_session_duration,
+                desired_app_launcher_visible, [application_domain], cf_access_policies_or_ids,
                 desired_allowed_idps, desired_auto_redirect, use_reusable
             )
 

--- a/dockflare/app/core/docker_handler.py
+++ b/dockflare/app/core/docker_handler.py
@@ -29,7 +29,7 @@ from app.core.state_manager import managed_rules, state_lock, save_state
 from app.core.tunnel_manager import update_cloudflare_config
 from app.core.cloudflare_api import create_cloudflare_dns_record, get_zone_id_from_name, list_account_zones
 from app.core.access_manager import handle_access_policy_from_labels
-from app.core.utils import get_rule_key, get_label
+from app.core.utils import get_rule_key, get_label, normalize_access_group_value
 
 def is_valid_hostname(hostname):
     if not hostname:
@@ -196,17 +196,14 @@ def process_container_start(container_obj):
                 http_host_header_indexed_val = get_label(labels, f"{index}.httpHostHeader", default_http_host_header_label)
 
                 access_groups_indexed = get_label(labels, f"{index}.access.groups")
-                access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
+                raw_access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
                 access_policy_type_indexed = get_label(labels, f"{index}.access.policy", default_access_policy_type_label)
 
-                if access_policy_type_indexed == "bypass" and not access_group_indexed and not access_groups_indexed:
+                if access_policy_type_indexed == "bypass" and not raw_access_group_indexed and not access_groups_indexed:
                     logging.info(f"DOCKER_HANDLER: Legacy label 'dockflare.{index}.access.policy=bypass' detected for {container_name_val}. Migrating to 'dockflare.{index}.access.group=public-default-bypass'.")
                     access_group_indexed = ["public-default-bypass"]
                     access_policy_type_indexed = None
-                elif access_group_indexed and "bypass" in access_group_indexed and not access_groups_indexed:
-                    logging.info(f"DOCKER_HANDLER: Legacy group 'bypass' detected in index {index} for {container_name_val}. Migrating to 'public-default-bypass'.")
-                    access_group_indexed = ["public-default-bypass" if g == "bypass" else g for g in access_group_indexed]
-                elif access_policy_type_indexed == "authenticate" and not access_group_indexed and not access_groups_indexed:
+                elif access_policy_type_indexed == "authenticate" and not raw_access_group_indexed and not access_groups_indexed:
                     from app.core.cloudflare_api import get_cloudflare_account_email
                     account_email = get_cloudflare_account_email()
                     if account_email:
@@ -216,13 +213,21 @@ def process_container_start(container_obj):
                     else:
                         logging.warning(f"DOCKER_HANDLER: Cannot migrate 'dockflare.{index}.access.policy=authenticate' for {container_name_val}. Cloudflare account email not available. Skipping access policy creation. Use 'dockflare.{index}.access.group=<group>' instead.")
                         access_policy_type_indexed = None
-
-                if access_groups_indexed:
-                    access_group_indexed = [gid.strip() for gid in access_groups_indexed.split(',')]
-                elif access_group_indexed:
-                    access_group_indexed = [access_group_indexed.strip()] if isinstance(access_group_indexed, str) else access_group_indexed
+                        access_group_indexed = None
                 else:
-                    access_group_indexed = default_access_group
+                    if access_groups_indexed:
+                        parsed_groups = [gid.strip() for gid in access_groups_indexed.split(',') if gid and gid.strip()]
+                    else:
+                        parsed_groups = normalize_access_group_value(raw_access_group_indexed)
+                    if not parsed_groups:
+                        parsed_groups = list(default_access_group) if isinstance(default_access_group, list) else default_access_group
+                    if parsed_groups and any(g == "bypass" for g in parsed_groups):
+                        logging.info(f"DOCKER_HANDLER: Legacy group 'bypass' detected in index {index} for {container_name_val}. Migrating to 'public-default-bypass'.")
+                        parsed_groups = ["public-default-bypass" if g == "bypass" else g for g in parsed_groups]
+                    access_group_indexed = parsed_groups
+
+                if access_group_indexed and not isinstance(access_group_indexed, list):
+                    access_group_indexed = normalize_access_group_value(access_group_indexed)
                 access_app_name_indexed = get_label(labels, f"{index}.access.name", default_access_app_name_label)
                 access_session_duration_indexed = get_label(labels, f"{index}.access.session_duration", default_access_session_duration_label)
                 acc_launcher_val_idx = get_label(labels, f"{index}.access.app_launcher_visible", str(default_access_app_launcher_visible_label).lower())

--- a/dockflare/app/core/utils.py
+++ b/dockflare/app/core/utils.py
@@ -16,13 +16,14 @@
 #
 # dockflare/app/core/utils.py
 from app import config
+
+
 def get_rule_key(hostname, path):
-    
     path_str = str(path or "").strip()
     return f"{hostname}|{path_str}"
 
+
 def get_label(labels, key_suffix, default=None):
-    
     if config.CUSTOM_LABEL_PREFIX:
         custom_key = f"{config.CUSTOM_LABEL_PREFIX.rstrip('.')}.{key_suffix}"
         if custom_key in labels:
@@ -37,3 +38,44 @@ def get_label(labels, key_suffix, default=None):
         return labels[legacy_key]
 
     return default
+
+
+def normalize_access_group_value(value):
+    if value is None:
+        return []
+
+    if isinstance(value, list):
+        result = []
+        for item in value:
+            if item is None:
+                continue
+            if isinstance(item, str):
+                stripped = item.strip()
+                if stripped:
+                    result.append(stripped)
+            else:
+                result.append(str(item))
+        return result
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+
+    return [str(value)]
+
+
+def normalize_path_value(value):
+    if value is None:
+        return ""
+
+    path_str = str(value).strip()
+    if not path_str:
+        return ""
+
+    if not path_str.startswith('/'):
+        path_str = '/' + path_str
+
+    if len(path_str) > 1 and path_str.endswith('/'):
+        path_str = path_str.rstrip('/')
+
+    return path_str

--- a/dockflare/app/main.py
+++ b/dockflare/app/main.py
@@ -125,7 +125,8 @@ def start_core_services():
     from app.core.state_manager import identity_providers, save_state, state_lock, save_identity_provider
     logging.info("Syncing identity providers after setup...")
     try:
-        idps = idp_manager.list_identity_providers()
+        with app.app_context():
+            idps = idp_manager.list_identity_providers()
         if idps:
             with state_lock:
                 for idp in idps:

--- a/dockflare/app/web/api_v2_routes.py
+++ b/dockflare/app/web/api_v2_routes.py
@@ -56,23 +56,23 @@ from app.core.access_manager import (
     create_cloudflare_access_application,
     update_cloudflare_access_application,
     generate_access_app_config_hash,
-    find_cloudflare_access_application_by_hostname,
+    find_cloudflare_access_application_by_domain,
     handle_access_policy_from_labels
 )
 from app.core.reconciler import reconcile_state_threaded
 from app.core.docker_handler import is_valid_hostname, is_valid_service
-from app.core.utils import get_rule_key, get_label
+from app.core.utils import get_rule_key, get_label, normalize_access_group_value, normalize_path_value
 #----------------------------------------------------------!
-# UI endpoints are protected by session auth               !
+# UI endpoints are protected by session auth   nicht vergessen, immer checken bei änderungen.. don't waste time            !
 #----------------------------------------------------------!
 api_v2_bp = Blueprint('api_v2', __name__, url_prefix='/api/v2')
-# Nicht vergessen - This is important when adding a new agent endpoint don't forget to update in order to allow as by default all agent endpoints are protected by master api key auth
+
 _AGENT_ENDPOINT_ALLOWLIST = {
     'api_v2.agents_register',
     'api_v2.agents_get_commands',
     'api_v2.agents_post_events',
 }
-# Nicht vergessenn - This is important when adding a new UI endpoint don't forget to update in order to allow as by default all UI endpoints are protected by session auth
+
 _UI_ENDPOINT_ALLOWLIST = {
     'api_v2.manage_auth_settings',
     'api_v2.manage_auth_providers',
@@ -853,17 +853,14 @@ def process_agent_container_start(payload, agent_id):
                 http_host_header_indexed_val = get_label(labels, f"{index}.httpHostHeader", default_http_host_header_label)
 
                 access_groups_indexed = get_label(labels, f"{index}.access.groups")
-                access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
+                raw_access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
                 access_policy_type_indexed = get_label(labels, f"{index}.access.policy", default_access_policy_type_label)
 
-                if access_policy_type_indexed == "bypass" and not access_group_indexed and not access_groups_indexed:
+                if access_policy_type_indexed == "bypass" and not raw_access_group_indexed and not access_groups_indexed:
                     logging.info(f"AGENT_PROCESS: Legacy label 'dockflare.{index}.access.policy=bypass' detected for {container_name}. Migrating to 'dockflare.{index}.access.group=public-default-bypass'.")
                     access_group_indexed = ["public-default-bypass"]
                     access_policy_type_indexed = None
-                elif access_group_indexed and "bypass" in access_group_indexed and not access_groups_indexed:
-                    logging.info(f"AGENT_PROCESS: Legacy group 'bypass' detected in index {index} for {container_name}. Migrating to 'public-default-bypass'.")
-                    access_group_indexed = ["public-default-bypass" if g == "bypass" else g for g in access_group_indexed]
-                elif access_policy_type_indexed == "authenticate" and not access_group_indexed and not access_groups_indexed:
+                elif access_policy_type_indexed == "authenticate" and not raw_access_group_indexed and not access_groups_indexed:
                     from app.core.cloudflare_api import get_cloudflare_account_email
                     account_email = get_cloudflare_account_email()
                     if account_email:
@@ -873,13 +870,21 @@ def process_agent_container_start(payload, agent_id):
                     else:
                         logging.warning(f"AGENT_PROCESS: Cannot migrate 'dockflare.{index}.access.policy=authenticate' for {container_name}. Cloudflare account email not available. Skipping access policy creation. Use 'dockflare.{index}.access.group=<group>' instead.")
                         access_policy_type_indexed = None
-
-                if access_groups_indexed:
-                    access_group_indexed = [gid.strip() for gid in access_groups_indexed.split(',')]
-                elif access_group_indexed:
-                    access_group_indexed = [access_group_indexed.strip()] if isinstance(access_group_indexed, str) else access_group_indexed
+                        access_group_indexed = None
                 else:
-                    access_group_indexed = default_access_group
+                    if access_groups_indexed:
+                        parsed_groups = [gid.strip() for gid in access_groups_indexed.split(',') if gid and gid.strip()]
+                    else:
+                        parsed_groups = normalize_access_group_value(raw_access_group_indexed)
+                    if not parsed_groups:
+                        parsed_groups = list(default_access_group) if isinstance(default_access_group, list) else default_access_group
+                    if parsed_groups and any(g == "bypass" for g in parsed_groups):
+                        logging.info(f"AGENT_PROCESS: Legacy group 'bypass' detected in index {index} for {container_name}. Migrating to 'public-default-bypass'.")
+                        parsed_groups = ["public-default-bypass" if g == "bypass" else g for g in parsed_groups]
+                    access_group_indexed = parsed_groups
+
+                if access_group_indexed and not isinstance(access_group_indexed, list):
+                    access_group_indexed = normalize_access_group_value(access_group_indexed)
                 access_app_name_indexed = get_label(labels, f"{index}.access.name", default_access_app_name_label)
                 access_session_duration_indexed = get_label(labels, f"{index}.access.session_duration", default_access_session_duration_label)
                 acc_launcher_val_idx = get_label(labels, f"{index}.access.app_launcher_visible", str(default_access_app_launcher_visible_label).lower())
@@ -1193,21 +1198,20 @@ def delete_agent_key_permanently(key_id):
     if not key_id:
         return jsonify({"status": "error", "message": "Missing key ID"}), 400
 
-    # Get key info to validate it exists and is revoked
+    
     key_info = get_agent_key_info(key_id)
     if not key_info:
         return jsonify({"status": "error", "message": "Key not found"}), 404
 
-    # Security: Only allow deletion of revoked keys
+    
     if key_info.get("status") != "revoked":
         return jsonify({"status": "error", "message": "Can only permanently delete revoked keys"}), 400
 
-    # Audit logging before deletion
+    
     owner = key_info.get("owner", "unknown")
     revoked_at = key_info.get("revoked_at", "unknown")
     logging.info(f"ADMIN: Permanently deleting revoked key {key_id[:8]}... (owner: {owner}, revoked: {revoked_at})")
-
-    # Perform the permanent deletion
+    
     agent_key_store.remove_key(key_id)
 
     return jsonify({
@@ -1995,11 +1999,19 @@ def update_rule_access_policy(rule_key):
         if not current_rule:
             return jsonify({"status": "error", "message": f"Rule '{rule_key}' not found."}),
         
-        hostname_for_access_app = current_rule.get("hostname") 
+        hostname_for_access_app = current_rule.get("hostname")
         if not hostname_for_access_app:
             hostname_for_access_app = rule_key.split('|')[0]
             if not hostname_for_access_app:
                 return jsonify({"status": "error", "message": f"Cannot determine hostname for Access App for rule '{rule_key}'."}),
+
+        rule_path = normalize_path_value(current_rule.get("path"))
+        application_domain = hostname_for_access_app if not rule_path else f"{hostname_for_access_app}{rule_path}"
+
+        path_identifier = ""
+        if rule_path:
+            path_identifier = rule_path.lstrip('/') or "root"
+            path_identifier = path_identifier.replace('/', '-').replace(' ', '-')
 
         current_access_app_id = current_rule.get("access_app_id")
         session_duration = data.get('session_duration', current_rule.get("access_session_duration", "24h"))
@@ -2007,7 +2019,9 @@ def update_rule_access_policy(rule_key):
         allowed_idps_str = data.get('allowed_idps_str', current_rule.get("access_allowed_idps_str"))
         auto_redirect = data.get('auto_redirect', current_rule.get("access_auto_redirect", False))
 
-        desired_app_name = f"DockFlare-{hostname_for_access_app}" 
+        desired_app_name = f"DockFlare-{hostname_for_access_app}"
+        if path_identifier:
+            desired_app_name = f"{desired_app_name}-{path_identifier}"
         cf_access_policies = []
         final_policy_type_for_state = new_policy_type
         custom_rules_for_hash = None
@@ -2072,10 +2086,10 @@ def update_rule_access_policy(rule_key):
 
             effective_app_id_for_operation = current_access_app_id
             if not effective_app_id_for_operation: 
-                existing_cf_app = find_cloudflare_access_application_by_hostname(hostname_for_access_app)
+                existing_cf_app = find_cloudflare_access_application_by_domain(application_domain)
                 if existing_cf_app and existing_cf_app.get("id"):
                     effective_app_id_for_operation = existing_cf_app.get("id")
-                    logging.info(f"Found existing Access App ID '{effective_app_id_for_operation}' on Cloudflare for {hostname_for_access_app}. Will update.")
+                    logging.info(f"Found existing Access App ID '{effective_app_id_for_operation}' on Cloudflare for {application_domain}. Will update.")
                     current_rule["access_app_id"] = effective_app_id_for_operation 
                     state_changed_locally = True
             
@@ -2085,8 +2099,8 @@ def update_rule_access_policy(rule_key):
                    current_rule.get("access_app_id") != effective_app_id_for_operation: 
                     
                     updated_app = update_cloudflare_access_application(
-                        effective_app_id_for_operation, hostname_for_access_app, desired_app_name,
-                        session_duration, app_launcher_visible, [hostname_for_access_app],
+                        effective_app_id_for_operation, application_domain, desired_app_name,
+                        session_duration, app_launcher_visible, [application_domain],
                         cf_access_policies, allowed_idps_list_for_app, auto_redirect
                     )
                     if updated_app:
@@ -2107,8 +2121,8 @@ def update_rule_access_policy(rule_key):
                     action_status_message = "No change in policy needed."
             else:
                 created_app = create_cloudflare_access_application(
-                    hostname_for_access_app, desired_app_name,
-                    session_duration, app_launcher_visible, [hostname_for_access_app],
+                    application_domain, desired_app_name,
+                    session_duration, app_launcher_visible, [application_domain],
                     cf_access_policies, allowed_idps_list_for_app, auto_redirect
                 )
                 if created_app and created_app.get("id"):

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -469,21 +469,26 @@ def access_policies_page():
 
     with state_lock:
         for rule in managed_rules.values():
-            
-            if rule.get('source') in ['docker', 'agent']:
-                hostname = rule.get('hostname', 'Unknown')
-                group_id_val = rule.get('access_group_id')
-                if isinstance(group_id_val, list):
-                    for gid in group_id_val:
-                        used_group_ids.add(gid)
-                        if gid not in group_usage:
-                            group_usage[gid] = []
-                        group_usage[gid].append(hostname)
-                elif group_id_val:
-                    used_group_ids.add(group_id_val)
-                    if group_id_val not in group_usage:
-                        group_usage[group_id_val] = []
-                    group_usage[group_id_val].append(hostname)
+            group_id_val = rule.get('access_group_id')
+            if not group_id_val:
+                continue
+
+            hostname = rule.get('hostname', 'Unknown')
+            path = rule.get('path')
+            display_name = hostname
+            if path:
+                path_str = str(path).strip()
+                if path_str and path_str != "None":
+                    normalized_path = path_str if path_str.startswith('/') else f"/{path_str}"
+                    display_name = f"{hostname}{normalized_path}"
+
+            group_ids = group_id_val if isinstance(group_id_val, list) else [group_id_val]
+            for gid in group_ids:
+                if not gid:
+                    continue
+                used_group_ids.add(gid)
+                group_usage.setdefault(gid, set()).add(display_name)
+
         groups_for_template_raw = copy.deepcopy(access_groups)
         groups_for_template = {
             gid: group for gid, group in groups_for_template_raw.items()
@@ -503,7 +508,7 @@ def access_policies_page():
         'access_policies.html',
         access_groups=groups_for_template,
         used_group_ids=used_group_ids,
-        group_usage=group_usage,
+        group_usage={gid: sorted(list(hosts)) for gid, hosts in group_usage.items()},
         countries=countries,
         ACCOUNT_ID_FOR_DISPLAY=cf_account_id if cf_account_id else "Not Configured"
     )

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -61,11 +61,11 @@ from app.core.access_manager import (
     create_cloudflare_access_application,
     update_cloudflare_access_application,
     generate_access_app_config_hash,
-    find_cloudflare_access_application_by_hostname
+    find_cloudflare_access_application_by_domain
 )
 from app.core.reconciler import reconcile_state_threaded
 from app.core.docker_handler import is_valid_hostname, is_valid_service
-from app.core.utils import get_rule_key
+from app.core.utils import get_rule_key, normalize_path_value
 from app.core import backup_manager
 from app.web import config_loader
 from cryptography.fernet import Fernet
@@ -1250,6 +1250,19 @@ def ui_add_manual_rule_route():
         return redirect(url_for('web.status_page'))
     
     processed_path = f"/{path_input.lstrip('/')}" if path_input else None
+    normalized_path_for_app = normalize_path_value(processed_path)
+    application_domain = full_hostname if not normalized_path_for_app else f"{full_hostname}{normalized_path_for_app}"
+    path_identifier = ""
+    if normalized_path_for_app:
+        path_identifier = normalized_path_for_app.lstrip('/') or "root"
+        path_identifier = path_identifier.replace('/', '-').replace(' ', '-')
+    normalized_path_for_app = normalize_path_value(processed_path)
+    application_domain = full_hostname if not normalized_path_for_app else f"{full_hostname}{normalized_path_for_app}"
+    path_identifier = ""
+    if normalized_path_for_app:
+        path_identifier = normalized_path_for_app.lstrip('/') or "root"
+        path_identifier = path_identifier.replace('/', '-').replace(' ', '-')
+
     key_for_managed_rules = get_rule_key(full_hostname, processed_path)
     
     processed_service_for_cf = ""
@@ -1345,6 +1358,10 @@ def ui_add_manual_rule_route():
                 access_group_id = manual_access_group_ids
                 access_policy_type = "group"
                 desired_app_name = f"DockFlare-{full_hostname}"
+                if path_identifier:
+                    desired_app_name = f"{desired_app_name}-{path_identifier}"
+                if path_identifier:
+                    desired_app_name = f"{desired_app_name}-{path_identifier}"
 
                 access_app_config_hash = generate_access_app_config_hash(
                     policy_type="group", session_duration=desired_session_duration,
@@ -1355,17 +1372,17 @@ def ui_add_manual_rule_route():
                     group_id=','.join(access_group_id)
                 )
 
-                existing_app = find_cloudflare_access_application_by_hostname(full_hostname)
+                existing_app = find_cloudflare_access_application_by_domain(application_domain)
                 if existing_app:
                     app_result = update_cloudflare_access_application(
-                        existing_app['id'], full_hostname, desired_app_name, desired_session_duration,
-                        desired_app_launcher_visible, [full_hostname], cf_access_policies_or_ids,
+                        existing_app['id'], application_domain, desired_app_name, desired_session_duration,
+                        desired_app_launcher_visible, [application_domain], cf_access_policies_or_ids,
                         desired_allowed_idps, desired_auto_redirect, use_reusable
                     )
                 else:
                     app_result = create_cloudflare_access_application(
-                        full_hostname, desired_app_name, desired_session_duration,
-                        desired_app_launcher_visible, [full_hostname], cf_access_policies_or_ids,
+                        application_domain, desired_app_name, desired_session_duration,
+                        desired_app_launcher_visible, [application_domain], cf_access_policies_or_ids,
                         desired_allowed_idps, desired_auto_redirect, use_reusable
                     )
 
@@ -1385,6 +1402,8 @@ def ui_add_manual_rule_route():
                     access_group_id = [default_bypass_id]
                     access_policy_type = "group"
                     desired_app_name = f"DockFlare-{full_hostname}"
+                    if path_identifier:
+                        desired_app_name = f"{desired_app_name}-{path_identifier}"
 
                     access_app_config_hash = generate_access_app_config_hash(
                         policy_type="group", session_duration="24h",
@@ -1395,17 +1414,17 @@ def ui_add_manual_rule_route():
                         group_id=default_bypass_id
                     )
 
-                    existing_app = find_cloudflare_access_application_by_hostname(full_hostname)
+                    existing_app = find_cloudflare_access_application_by_domain(application_domain)
                     if existing_app:
                         app_result = update_cloudflare_access_application(
-                            existing_app['id'], full_hostname, desired_app_name, "24h",
-                            False, [full_hostname], [cf_policy_id],
+                            existing_app['id'], application_domain, desired_app_name, "24h",
+                            False, [application_domain], [cf_policy_id],
                             None, False, True
                         )
                     else:
                         app_result = create_cloudflare_access_application(
-                            full_hostname, desired_app_name, "24h",
-                            False, [full_hostname], [cf_policy_id],
+                            application_domain, desired_app_name, "24h",
+                            False, [application_domain], [cf_policy_id],
                             None, False, True
                         )
 
@@ -1628,17 +1647,17 @@ def ui_edit_manual_rule_route():
                     custom_access_rules_str=json.dumps(cf_access_policies_or_ids, sort_keys=True),
                     group_id=','.join(access_group_id)
                 )
-                existing_app = find_cloudflare_access_application_by_hostname(full_hostname)
+                existing_app = find_cloudflare_access_application_by_domain(application_domain)
                 if existing_app:
                     app_result = update_cloudflare_access_application(
-                        existing_app['id'], full_hostname, desired_app_name, desired_session_duration,
-                        desired_app_launcher_visible, [full_hostname], cf_access_policies_or_ids,
+                        existing_app['id'], application_domain, desired_app_name, desired_session_duration,
+                        desired_app_launcher_visible, [application_domain], cf_access_policies_or_ids,
                         desired_allowed_idps, desired_auto_redirect, use_reusable
                     )
                 else:
                     app_result = create_cloudflare_access_application(
-                        full_hostname, desired_app_name, desired_session_duration,
-                        desired_app_launcher_visible, [full_hostname], cf_access_policies_or_ids,
+                        application_domain, desired_app_name, desired_session_duration,
+                        desired_app_launcher_visible, [application_domain], cf_access_policies_or_ids,
                         desired_allowed_idps, desired_auto_redirect, use_reusable
                     )
                 if app_result:
@@ -1654,6 +1673,8 @@ def ui_edit_manual_rule_route():
                     access_group_id = [default_bypass_id]
                     access_policy_type = "group"
                     desired_app_name = f"DockFlare-{full_hostname}"
+                    if path_identifier:
+                        desired_app_name = f"{desired_app_name}-{path_identifier}"
 
                     access_app_config_hash = generate_access_app_config_hash(
                         policy_type="group", session_duration="24h",
@@ -1664,17 +1685,17 @@ def ui_edit_manual_rule_route():
                         group_id=default_bypass_id
                     )
 
-                    existing_app = find_cloudflare_access_application_by_hostname(full_hostname)
+                    existing_app = find_cloudflare_access_application_by_domain(application_domain)
                     if existing_app:
                         app_result = update_cloudflare_access_application(
-                            existing_app['id'], full_hostname, desired_app_name, "24h",
-                            False, [full_hostname], [cf_policy_id],
+                            existing_app['id'], application_domain, desired_app_name, "24h",
+                            False, [application_domain], [cf_policy_id],
                             None, False, True
                         )
                     else:
                         app_result = create_cloudflare_access_application(
-                            full_hostname, desired_app_name, "24h",
-                            False, [full_hostname], [cf_policy_id],
+                            application_domain, desired_app_name, "24h",
+                            False, [application_domain], [cf_policy_id],
                             None, False, True
                         )
 
@@ -2036,17 +2057,15 @@ def create_zone_default_policy():
     wildcard_hostname = f"*.{zone_name}"
 
     try:
-        # Check if it already exists
-        existing = find_cloudflare_access_application_by_hostname(wildcard_hostname)
+        
+        existing = find_cloudflare_access_application_by_domain(wildcard_hostname)
         if existing:
             flash(f"A wildcard policy for '{wildcard_hostname}' already exists.", "warning")
             return redirect(url_for('web.access_policies_page'))
-
-        # Get the Cloudflare policy ID
+        
         from app.core import reusable_policies
         cf_policy_id = group.get("cf_policy_id") or group.get("id")
-
-        # Sync to Cloudflare if needed
+        
         if not cf_policy_id or cf_policy_id == access_group_id:
             policy_id = reusable_policies.sync_access_group_to_reusable_policy(access_group_id)
             if policy_id:
@@ -2055,8 +2074,7 @@ def create_zone_default_policy():
                     access_groups[access_group_id]["cf_policy_id"] = policy_id
                     access_groups[access_group_id]["id"] = policy_id
                     save_state()
-
-        # Create the Access Application
+        
         app_name = f"Zone Default: {wildcard_hostname}"
         session_duration = group.get("session_duration", "24h")
         app_launcher_visible = group.get("app_launcher_visible", False)
@@ -2100,8 +2118,7 @@ def sync_access_groups_from_cloudflare():
 
     try:
         from app.core import reusable_policies
-
-        # Get sync_all parameter from form (defaults to false for backward compatibility)
+        
         sync_all = request.form.get('sync_all', 'false').lower() in ['true', '1', 't', 'yes']
 
         result = reusable_policies.import_cloudflare_reusable_policies(sync_all=sync_all)


### PR DESCRIPTION
## [v3.0.3] - 2025-10-05

### Hotfix
- **Access Policy Path Regression:** Restored indexed label support for Cloudflare Access applications so path-specific rules (e.g., `dockflare.0.path=/auth/google/callback`) once again create distinct Access Apps linked to their reusable policies. Fixes broken policy sync introduced with the reusable policy migration in v3.0.3.
- **Access Policy Usage Display:** Corrected the “Used by these services” list so manual rules assigned to an Access Group appear alongside Docker/Agent-managed services, with paths shown when applicable.