### PR TITLE
DockFlare v3.0.5: A Tale of Two Toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v3.0.5] - 2025-10-14
+
+### Added
+- **HTTP/2 Origin Support:** Added support for enabling HTTP/2 protocol between `cloudflared` and origin services via the new `dockflare.http2_origin` label and UI controls. Required for gRPC services. Only applies to HTTP/HTTPS services.
+- **Disable Chunked Encoding Support:** Added support for disabling chunked transfer encoding over HTTP/1.1 via the new `dockflare.disable_chunked_encoding` label and UI controls. Useful for WSGI servers (Flask, Django, FastAPI) and other origins that don't properly support chunked requests. Only applies to HTTP/HTTPS services.
+
+---
+
 ## [v3.0.4] - 2025-10-11
 
 ### Added

--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ChrispyBacon-dev/DockFlare/releases"><img src="https://img.shields.io/badge/Release-v3.0.4-blue.svg?style=for-the-badge" alt="Release"></a>
+  <a href="https://github.com/ChrispyBacon-dev/DockFlare/releases"><img src="https://img.shields.io/badge/Release-v3.0.5-blue.svg?style=for-the-badge" alt="Release"></a>
   <a href="https://hub.docker.com/r/alplat/dockflare"><img src="https://img.shields.io/docker/pulls/alplat/dockflare?style=for-the-badge" alt="Docker Pulls"></a>
   <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Made%20with-Python-1f425f.svg?style=for-the-badge" alt="Python"></a>
   <a href="https://github.com/ChrispyBacon-dev/DockFlare/blob/main/LICENSE.MD"><img src="https://img.shields.io/badge/License-GPL--3.0-blue.svg?style=for-the-badge" alt="License"></a>

--- a/dockflare/app/config.py
+++ b/dockflare/app/config.py
@@ -34,7 +34,7 @@ def _get_int_env(name, default, minimum=None):
         return default
 
 # --- DockFlare Version ---
-APP_VERSION = "v3.0.4"
+APP_VERSION = "v3.0.5"
 # --- web: https://dockflare.app ---
 # --- github: https://github.com/ChrispyBacon-dev/DockFlare ---
 

--- a/dockflare/app/core/docker_handler.py
+++ b/dockflare/app/core/docker_handler.py
@@ -157,6 +157,7 @@ def process_container_start(container_obj):
             service_label = get_label(labels, "service")
             zone_name_label = get_label(labels, "zonename")
             no_tls_verify_label = get_label(labels, "no_tls_verify", "false").lower() in ["true", "1", "t", "yes"]
+            http2_origin_label = get_label(labels, "http2_origin", "false").lower() in ["true", "1", "t", "yes"]
 
             if hostname_label and service_label:
                 if is_valid_hostname(hostname_label) and is_valid_service(service_label):
@@ -166,6 +167,7 @@ def process_container_start(container_obj):
                         "no_tls_verify": no_tls_verify_label,
                         "origin_server_name": default_originsrvname_label.strip() if default_originsrvname_label else None,
                         "http_host_header": default_http_host_header_label.strip() if default_http_host_header_label else None,
+                        "http2_origin": http2_origin_label,
                         "access_group": default_access_group,
                         "access_policy_type": default_access_policy_type_label,
                         "access_app_name": default_access_app_name_label,
@@ -194,6 +196,8 @@ def process_container_start(container_obj):
                 no_tls_verify_indexed = no_tls_verify_indexed_val.lower() in ["true", "1", "t", "yes"]
                 originsrvname_indexed_val = get_label(labels, f"{index}.originsrvname", default_originsrvname_label)
                 http_host_header_indexed_val = get_label(labels, f"{index}.httpHostHeader", default_http_host_header_label)
+                http2_origin_indexed_val = get_label(labels, f"{index}.http2_origin", str(http2_origin_label).lower())
+                http2_origin_indexed = http2_origin_indexed_val.lower() in ["true", "1", "t", "yes"]
 
                 access_groups_indexed = get_label(labels, f"{index}.access.groups")
                 raw_access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
@@ -244,6 +248,7 @@ def process_container_start(container_obj):
                         "no_tls_verify": no_tls_verify_indexed,
                         "origin_server_name": originsrvname_indexed_val.strip() if originsrvname_indexed_val else None,
                         "http_host_header": http_host_header_indexed_val.strip() if http_host_header_indexed_val else None,
+                        "http2_origin": http2_origin_indexed,
                         "access_group": access_group_indexed,
                         "access_policy_type": access_policy_type_indexed,
                         "access_app_name": access_app_name_indexed,
@@ -285,6 +290,7 @@ def process_container_start(container_obj):
                 no_tls_verify_from_item = config_item["no_tls_verify"]
                 origin_server_name_from_item = config_item.get("origin_server_name")
                 http_host_header_from_item = config_item.get("http_host_header")
+                http2_origin_from_item = config_item.get("http2_origin", False)
 
                 target_zone_id = None
                 detected_zone_name = zone_name_from_item
@@ -349,6 +355,9 @@ def process_container_start(container_obj):
                         if existing_rule.get("http_host_header") != http_host_header_from_item:
                             existing_rule["http_host_header"] = http_host_header_from_item
                             rule_data_changed = True
+                        if existing_rule.get("http2_origin") != http2_origin_from_item:
+                            existing_rule["http2_origin"] = http2_origin_from_item
+                            rule_data_changed = True
 
                         existing_rule["source"] = "docker"
                         if master_tunnel_id and existing_rule.get("tunnel_id") != master_tunnel_id:
@@ -384,6 +393,7 @@ def process_container_start(container_obj):
                             "no_tls_verify": no_tls_verify_from_item,
                             "origin_server_name": origin_server_name_from_item,
                             "http_host_header": http_host_header_from_item,
+                            "http2_origin": http2_origin_from_item,
                             "access_app_id": None,
                             "access_policy_type": None,
                             "access_app_config_hash": None,

--- a/dockflare/app/core/docker_handler.py
+++ b/dockflare/app/core/docker_handler.py
@@ -158,6 +158,7 @@ def process_container_start(container_obj):
             zone_name_label = get_label(labels, "zonename")
             no_tls_verify_label = get_label(labels, "no_tls_verify", "false").lower() in ["true", "1", "t", "yes"]
             http2_origin_label = get_label(labels, "http2_origin", "false").lower() in ["true", "1", "t", "yes"]
+            disable_chunked_encoding_label = get_label(labels, "disable_chunked_encoding", "false").lower() in ["true", "1", "t", "yes"]
 
             if hostname_label and service_label:
                 if is_valid_hostname(hostname_label) and is_valid_service(service_label):
@@ -168,6 +169,7 @@ def process_container_start(container_obj):
                         "origin_server_name": default_originsrvname_label.strip() if default_originsrvname_label else None,
                         "http_host_header": default_http_host_header_label.strip() if default_http_host_header_label else None,
                         "http2_origin": http2_origin_label,
+                        "disable_chunked_encoding": disable_chunked_encoding_label,
                         "access_group": default_access_group,
                         "access_policy_type": default_access_policy_type_label,
                         "access_app_name": default_access_app_name_label,
@@ -198,6 +200,8 @@ def process_container_start(container_obj):
                 http_host_header_indexed_val = get_label(labels, f"{index}.httpHostHeader", default_http_host_header_label)
                 http2_origin_indexed_val = get_label(labels, f"{index}.http2_origin", str(http2_origin_label).lower())
                 http2_origin_indexed = http2_origin_indexed_val.lower() in ["true", "1", "t", "yes"]
+                disable_chunked_encoding_indexed_val = get_label(labels, f"{index}.disable_chunked_encoding", str(disable_chunked_encoding_label).lower())
+                disable_chunked_encoding_indexed = disable_chunked_encoding_indexed_val.lower() in ["true", "1", "t", "yes"]
 
                 access_groups_indexed = get_label(labels, f"{index}.access.groups")
                 raw_access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
@@ -249,6 +253,7 @@ def process_container_start(container_obj):
                         "origin_server_name": originsrvname_indexed_val.strip() if originsrvname_indexed_val else None,
                         "http_host_header": http_host_header_indexed_val.strip() if http_host_header_indexed_val else None,
                         "http2_origin": http2_origin_indexed,
+                        "disable_chunked_encoding": disable_chunked_encoding_indexed,
                         "access_group": access_group_indexed,
                         "access_policy_type": access_policy_type_indexed,
                         "access_app_name": access_app_name_indexed,
@@ -291,6 +296,7 @@ def process_container_start(container_obj):
                 origin_server_name_from_item = config_item.get("origin_server_name")
                 http_host_header_from_item = config_item.get("http_host_header")
                 http2_origin_from_item = config_item.get("http2_origin", False)
+                disable_chunked_encoding_from_item = config_item.get("disable_chunked_encoding", False)
 
                 target_zone_id = None
                 detected_zone_name = zone_name_from_item
@@ -358,6 +364,9 @@ def process_container_start(container_obj):
                         if existing_rule.get("http2_origin") != http2_origin_from_item:
                             existing_rule["http2_origin"] = http2_origin_from_item
                             rule_data_changed = True
+                        if existing_rule.get("disable_chunked_encoding") != disable_chunked_encoding_from_item:
+                            existing_rule["disable_chunked_encoding"] = disable_chunked_encoding_from_item
+                            rule_data_changed = True
 
                         existing_rule["source"] = "docker"
                         if master_tunnel_id and existing_rule.get("tunnel_id") != master_tunnel_id:
@@ -394,6 +403,7 @@ def process_container_start(container_obj):
                             "origin_server_name": origin_server_name_from_item,
                             "http_host_header": http_host_header_from_item,
                             "http2_origin": http2_origin_from_item,
+                            "disable_chunked_encoding": disable_chunked_encoding_from_item,
                             "access_app_id": None,
                             "access_policy_type": None,
                             "access_app_config_hash": None,

--- a/dockflare/app/core/state_manager.py
+++ b/dockflare/app/core/state_manager.py
@@ -143,6 +143,7 @@ def load_state():
                 rule_copy.setdefault("zone_name", None)
                 rule_copy.setdefault("no_tls_verify", False)
                 rule_copy.setdefault("origin_server_name", None)
+                rule_copy.setdefault("http2_origin", False)
 
                 tunnel_name = rule_copy.get("tunnel_name")
                 if not tunnel_name or tunnel_name == "dockflare-tunnel":
@@ -500,6 +501,7 @@ def save_state():
                 "no_tls_verify": rule.get("no_tls_verify", False),
                 "origin_server_name": rule.get("origin_server_name"),
                 "http_host_header": rule.get("http_host_header"),
+                "http2_origin": rule.get("http2_origin", False),
                 "access_app_id": rule.get("access_app_id"),
                 "access_policy_type": rule.get("access_policy_type"),
                 "access_app_config_hash": rule.get("access_app_config_hash"),

--- a/dockflare/app/core/state_manager.py
+++ b/dockflare/app/core/state_manager.py
@@ -144,6 +144,7 @@ def load_state():
                 rule_copy.setdefault("no_tls_verify", False)
                 rule_copy.setdefault("origin_server_name", None)
                 rule_copy.setdefault("http2_origin", False)
+                rule_copy.setdefault("disable_chunked_encoding", False)
 
                 tunnel_name = rule_copy.get("tunnel_name")
                 if not tunnel_name or tunnel_name == "dockflare-tunnel":
@@ -502,6 +503,7 @@ def save_state():
                 "origin_server_name": rule.get("origin_server_name"),
                 "http_host_header": rule.get("http_host_header"),
                 "http2_origin": rule.get("http2_origin", False),
+                "disable_chunked_encoding": rule.get("disable_chunked_encoding", False),
                 "access_app_id": rule.get("access_app_id"),
                 "access_policy_type": rule.get("access_policy_type"),
                 "access_app_config_hash": rule.get("access_app_config_hash"),

--- a/dockflare/app/core/tunnel_manager.py
+++ b/dockflare/app/core/tunnel_manager.py
@@ -261,6 +261,8 @@ def _build_ingress_entry_from_rule(rule_details):
         http_host_header = rule_details.get("http_host_header") or rule_details.get("httpHostHeader")
         if http_host_header:
             origin_request["httpHostHeader"] = http_host_header
+        if rule_details.get("http2_origin"):
+            origin_request["http2Origin"] = True
     if origin_request:
         entry["originRequest"] = origin_request
     return entry
@@ -299,7 +301,8 @@ def _ingress_to_comparable(rule):
     no_tls = bool(origin.get("noTLSVerify"))
     origin_name = origin.get("originServerName") or ""
     http_host = origin.get("httpHostHeader") or ""
-    return (hostname, service, path, no_tls, origin_name, http_host)
+    http2_origin = bool(origin.get("http2Origin"))
+    return (hostname, service, path, no_tls, origin_name, http_host, http2_origin)
 
 
 def _is_catch_all_rule(rule):

--- a/dockflare/app/core/tunnel_manager.py
+++ b/dockflare/app/core/tunnel_manager.py
@@ -263,6 +263,8 @@ def _build_ingress_entry_from_rule(rule_details):
             origin_request["httpHostHeader"] = http_host_header
         if rule_details.get("http2_origin"):
             origin_request["http2Origin"] = True
+        if rule_details.get("disable_chunked_encoding"):
+            origin_request["disableChunkedEncoding"] = True
     if origin_request:
         entry["originRequest"] = origin_request
     return entry
@@ -302,7 +304,8 @@ def _ingress_to_comparable(rule):
     origin_name = origin.get("originServerName") or ""
     http_host = origin.get("httpHostHeader") or ""
     http2_origin = bool(origin.get("http2Origin"))
-    return (hostname, service, path, no_tls, origin_name, http_host, http2_origin)
+    disable_chunked = bool(origin.get("disableChunkedEncoding"))
+    return (hostname, service, path, no_tls, origin_name, http_host, http2_origin, disable_chunked)
 
 
 def _is_catch_all_rule(rule):

--- a/dockflare/app/static/js/main.js
+++ b/dockflare/app/static/js/main.js
@@ -229,6 +229,9 @@ function initializeEditRuleModal() {
                 const httpHostHeaderField = modal.querySelector('#edit_manual_http_host_header');
                 if (httpHostHeaderField) httpHostHeaderField.value = details.http_host_header || '';
 
+                const http2OriginField = modal.querySelector('#edit_http2_origin');
+                if (http2OriginField) http2OriginField.checked = details.http2_origin || false;
+
                 const tunnelDisplay = modal.querySelector('#edit_rule_tunnel_value');
                 const zoneDisplay = modal.querySelector('#edit_rule_zone_value');
                 const agentHint = modal.querySelector('#edit_rule_agent_hint');

--- a/dockflare/app/static/js/main.js
+++ b/dockflare/app/static/js/main.js
@@ -232,6 +232,9 @@ function initializeEditRuleModal() {
                 const http2OriginField = modal.querySelector('#edit_http2_origin');
                 if (http2OriginField) http2OriginField.checked = details.http2_origin || false;
 
+                const disableChunkedEncodingField = modal.querySelector('#edit_disable_chunked_encoding');
+                if (disableChunkedEncodingField) disableChunkedEncodingField.checked = details.disable_chunked_encoding || false;
+
                 const tunnelDisplay = modal.querySelector('#edit_rule_tunnel_value');
                 const zoneDisplay = modal.querySelector('#edit_rule_zone_value');
                 const agentHint = modal.querySelector('#edit_rule_agent_hint');

--- a/dockflare/app/templates/docs/Container-Labels.md
+++ b/dockflare/app/templates/docs/Container-Labels.md
@@ -16,6 +16,7 @@ These labels control the fundamental routing and service definition for a contai
 | `dockflare.no_tls_verify` | If set to `true`, disables TLS certificate verification for the connection between `cloudflared` and your origin service. Useful for origins with self-signed certificates. | `dockflare.no_tls_verify=true` |
 | `dockflare.originsrvname` | Sets a specific Server Name Indication (SNI) hostname for the TLS connection to the origin. This is also known as "Origin Server Name" in the Cloudflare dashboard. | `dockflare.originsrvname=internal.service.local` |
 | `dockflare.httpHostHeader` | Overrides the `Host` header sent from `cloudflared` to your origin service. | `dockflare.httpHostHeader=custom-host.internal` |
+| `dockflare.http2_origin` | If set to `true`, enables HTTP/2 protocol for the connection between `cloudflared` and your origin service. Required for gRPC services. Only applies to HTTP/HTTPS services. | `dockflare.http2_origin=true` |
 
 > **Tip:** Starting with DockFlare v3.0, you can skip `dockflare.zonename` for most workloads. The master detects the correct Cloudflare zone by matching the hostname suffix and only falls back to the configured default zone when it cannot find a match. Provide the label when you intentionally want to place a record in a different zone.
 

--- a/dockflare/app/templates/docs/Container-Labels.md
+++ b/dockflare/app/templates/docs/Container-Labels.md
@@ -17,6 +17,7 @@ These labels control the fundamental routing and service definition for a contai
 | `dockflare.originsrvname` | Sets a specific Server Name Indication (SNI) hostname for the TLS connection to the origin. This is also known as "Origin Server Name" in the Cloudflare dashboard. | `dockflare.originsrvname=internal.service.local` |
 | `dockflare.httpHostHeader` | Overrides the `Host` header sent from `cloudflared` to your origin service. | `dockflare.httpHostHeader=custom-host.internal` |
 | `dockflare.http2_origin` | If set to `true`, enables HTTP/2 protocol for the connection between `cloudflared` and your origin service. Required for gRPC services. Only applies to HTTP/HTTPS services. | `dockflare.http2_origin=true` |
+| `dockflare.disable_chunked_encoding` | If set to `true`, disables chunked transfer encoding over HTTP/1.1. Useful for WSGI servers (Flask, Django, FastAPI) and other origins that don't properly support chunked requests. Only applies to HTTP/HTTPS services. | `dockflare.disable_chunked_encoding=true` |
 
 > **Tip:** Starting with DockFlare v3.0, you can skip `dockflare.zonename` for most workloads. The master detects the correct Cloudflare zone by matching the hostname suffix and only falls back to the configured default zone when it cannot find a match. Provide the label when you intentionally want to place a record in a different zone.
 

--- a/dockflare/app/templates/status_page.html
+++ b/dockflare/app/templates/status_page.html
@@ -196,7 +196,10 @@
                                            {% endif %}
                                            {% if details.http_host_header %}
                                                <span class="badge badge-info badge-xs ml-1" title="HTTP Host Header: {{ details.http_host_header }}">Host: {{ details.http_host_header | truncate(20, True) }}</span>
-                                           {% endif %}    
+                                           {% endif %}
+                                           {% if details.http2_origin %}
+                                               <span class="badge badge-success badge-xs ml-1" title="HTTP/2 protocol enabled for origin connection">HTTP/2 Origin</span>
+                                           {% endif %}
                                        </div>
                                    </td>
                                    <td class="p-3 whitespace-nowrap">
@@ -503,6 +506,13 @@
                                 <span class="label-text-alt">Overrides the <code>Host</code> header sent to your origin server. Useful for origins expecting a different hostname than the public one. (Only applies to HTTP/HTTPS services).</span>
                             </label>
                         </div>
+                        <div id="manual_http2_origin_div" class="form-control">
+                          <label class="label cursor-pointer justify-start gap-2">
+                            <input type="checkbox" name="manual_http2_origin" id="manual_http2_origin" class="checkbox checkbox-sm" />
+                            <span class="label-text">Enable HTTP/2 Origin</span>
+                          </label>
+                          <div class="text-xs opacity-60 ml-8">Enable HTTP/2 protocol between Cloudflare and your origin server. Required for gRPC services. (Only applies to HTTP/HTTPS services).</div>
+                        </div>
                     </div>
                 </div>
                 <div id="manual_rule_feedback" class="hidden alert mt-4"></div>
@@ -639,6 +649,13 @@
                             <label class="label">
                                 <span class="label-text-alt">Overrides the <code>Host</code> header sent to your origin server. Useful for origins expecting a different hostname than the public one. (Only applies to HTTP/HTTPS services).</span>
                             </label>
+                        </div>
+                        <div id="edit_http2_origin_div" class="form-control">
+                          <label class="label cursor-pointer justify-start gap-2">
+                            <input type="checkbox" name="edit_http2_origin" id="edit_http2_origin" class="checkbox checkbox-sm" />
+                            <span class="label-text">Enable HTTP/2 Origin</span>
+                          </label>
+                          <div class="text-xs opacity-60 ml-8">Enable HTTP/2 protocol between Cloudflare and your origin server. Required for gRPC services. (Only applies to HTTP/HTTPS services).</div>
                         </div>
                     </div>
                 </div>

--- a/dockflare/app/templates/status_page.html
+++ b/dockflare/app/templates/status_page.html
@@ -200,6 +200,9 @@
                                            {% if details.http2_origin %}
                                                <span class="badge badge-success badge-xs ml-1" title="HTTP/2 protocol enabled for origin connection">HTTP/2 Origin</span>
                                            {% endif %}
+                                           {% if details.disable_chunked_encoding %}
+                                               <span class="badge badge-info badge-xs ml-1" title="Chunked transfer encoding disabled for HTTP/1.1">No Chunked Encoding</span>
+                                           {% endif %}
                                        </div>
                                    </td>
                                    <td class="p-3 whitespace-nowrap">
@@ -513,6 +516,13 @@
                           </label>
                           <div class="text-xs opacity-60 ml-8">Enable HTTP/2 protocol between Cloudflare and your origin server. Required for gRPC services. (Only applies to HTTP/HTTPS services).</div>
                         </div>
+                        <div id="manual_disable_chunked_encoding_div" class="form-control">
+                          <label class="label cursor-pointer justify-start gap-2">
+                            <input type="checkbox" name="manual_disable_chunked_encoding" id="manual_disable_chunked_encoding" class="checkbox checkbox-sm" />
+                            <span class="label-text">Disable Chunked Encoding</span>
+                          </label>
+                          <div class="text-xs opacity-60 ml-8">Disables chunked transfer encoding over HTTP/1.1. Useful for WSGI servers (Flask, Django) and other origins that don't support chunked requests. (Only applies to HTTP/HTTPS services).</div>
+                        </div>
                     </div>
                 </div>
                 <div id="manual_rule_feedback" class="hidden alert mt-4"></div>
@@ -656,6 +666,13 @@
                             <span class="label-text">Enable HTTP/2 Origin</span>
                           </label>
                           <div class="text-xs opacity-60 ml-8">Enable HTTP/2 protocol between Cloudflare and your origin server. Required for gRPC services. (Only applies to HTTP/HTTPS services).</div>
+                        </div>
+                        <div id="edit_disable_chunked_encoding_div" class="form-control">
+                          <label class="label cursor-pointer justify-start gap-2">
+                            <input type="checkbox" name="edit_disable_chunked_encoding" id="edit_disable_chunked_encoding" class="checkbox checkbox-sm" />
+                            <span class="label-text">Disable Chunked Encoding</span>
+                          </label>
+                          <div class="text-xs opacity-60 ml-8">Disables chunked transfer encoding over HTTP/1.1. Useful for WSGI servers (Flask, Django) and other origins that don't support chunked requests. (Only applies to HTTP/HTTPS services).</div>
                         </div>
                     </div>
                 </div>

--- a/dockflare/app/web/api_v2_routes.py
+++ b/dockflare/app/web/api_v2_routes.py
@@ -562,6 +562,7 @@ def create_manual_rule_api():
                 "no_tls_verify": False,
                 "origin_server_name": None,
                 "http_host_header": None,
+                "http2_origin": False,
                 "access_app_id": None,
                 "access_policy_type": None,
                 "access_app_config_hash": None,
@@ -812,6 +813,7 @@ def process_agent_container_start(payload, agent_id):
             service_label = get_label(labels, "service")
             zone_name_label = get_label(labels, "zonename")
             no_tls_verify_label = get_label(labels, "no_tls_verify", "false").lower() in ["true", "1", "t", "yes"]
+            http2_origin_label = get_label(labels, "http2_origin", "false").lower() in ["true", "1", "t", "yes"]
 
             if hostname_label and service_label:
                 if is_valid_hostname(hostname_label) and is_valid_service(service_label):
@@ -823,6 +825,7 @@ def process_agent_container_start(payload, agent_id):
                         "no_tls_verify": no_tls_verify_label,
                         "origin_server_name": default_originsrvname_label.strip() if default_originsrvname_label else None,
                         "http_host_header": default_http_host_header_label.strip() if default_http_host_header_label else None,
+                        "http2_origin": http2_origin_label,
                         "access_group": default_access_group,
                         "access_policy_type": default_access_policy_type_label,
                         "access_app_name": default_access_app_name_label,
@@ -851,6 +854,8 @@ def process_agent_container_start(payload, agent_id):
                 no_tls_verify_indexed = no_tls_verify_indexed_val.lower() in ["true", "1", "t", "yes"]
                 originsrvname_indexed_val = get_label(labels, f"{index}.originsrvname", default_originsrvname_label)
                 http_host_header_indexed_val = get_label(labels, f"{index}.httpHostHeader", default_http_host_header_label)
+                http2_origin_indexed_val = get_label(labels, f"{index}.http2_origin", str(http2_origin_label).lower())
+                http2_origin_indexed = http2_origin_indexed_val.lower() in ["true", "1", "t", "yes"]
 
                 access_groups_indexed = get_label(labels, f"{index}.access.groups")
                 raw_access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
@@ -903,6 +908,7 @@ def process_agent_container_start(payload, agent_id):
                         "no_tls_verify": no_tls_verify_indexed,
                         "origin_server_name": originsrvname_indexed_val.strip() if originsrvname_indexed_val else None,
                         "http_host_header": http_host_header_indexed_val.strip() if http_host_header_indexed_val else None,
+                        "http2_origin": http2_origin_indexed,
                         "access_group": access_group_indexed,
                         "access_policy_type": access_policy_type_indexed,
                         "access_app_name": access_app_name_indexed,
@@ -940,6 +946,7 @@ def process_agent_container_start(payload, agent_id):
                 zone_name_from_item = config_item["zone_name"]
                 no_tls_verify_from_item = config_item["no_tls_verify"]
                 origin_server_name_from_item = config_item.get("origin_server_name")
+                http2_origin_from_item = config_item.get("http2_origin", False)
 
                 target_zone_id = None
                 if zone_name_from_item:
@@ -986,6 +993,9 @@ def process_agent_container_start(payload, agent_id):
                         if existing_rule.get("http_host_header") != http_host_header_from_item:
                             existing_rule["http_host_header"] = http_host_header_from_item
                             rule_data_changed = True
+                        if existing_rule.get("http2_origin") != http2_origin_from_item:
+                            existing_rule["http2_origin"] = http2_origin_from_item
+                            rule_data_changed = True
                         if existing_rule.get("tunnel_name") != assigned_tunnel_name:
                             existing_rule["tunnel_name"] = assigned_tunnel_name
                             rule_data_changed = True
@@ -1022,6 +1032,7 @@ def process_agent_container_start(payload, agent_id):
                             "no_tls_verify": no_tls_verify_from_item,
                             "origin_server_name": origin_server_name_from_item,
                             "http_host_header": config_item.get("http_host_header"),
+                            "http2_origin": http2_origin_from_item,
                             "access_app_id": None,
                             "access_policy_type": None,
                             "access_app_config_hash": None,

--- a/dockflare/app/web/api_v2_routes.py
+++ b/dockflare/app/web/api_v2_routes.py
@@ -563,6 +563,7 @@ def create_manual_rule_api():
                 "origin_server_name": None,
                 "http_host_header": None,
                 "http2_origin": False,
+                "disable_chunked_encoding": False,
                 "access_app_id": None,
                 "access_policy_type": None,
                 "access_app_config_hash": None,
@@ -814,6 +815,7 @@ def process_agent_container_start(payload, agent_id):
             zone_name_label = get_label(labels, "zonename")
             no_tls_verify_label = get_label(labels, "no_tls_verify", "false").lower() in ["true", "1", "t", "yes"]
             http2_origin_label = get_label(labels, "http2_origin", "false").lower() in ["true", "1", "t", "yes"]
+            disable_chunked_encoding_label = get_label(labels, "disable_chunked_encoding", "false").lower() in ["true", "1", "t", "yes"]
 
             if hostname_label and service_label:
                 if is_valid_hostname(hostname_label) and is_valid_service(service_label):
@@ -826,6 +828,7 @@ def process_agent_container_start(payload, agent_id):
                         "origin_server_name": default_originsrvname_label.strip() if default_originsrvname_label else None,
                         "http_host_header": default_http_host_header_label.strip() if default_http_host_header_label else None,
                         "http2_origin": http2_origin_label,
+                        "disable_chunked_encoding": disable_chunked_encoding_label,
                         "access_group": default_access_group,
                         "access_policy_type": default_access_policy_type_label,
                         "access_app_name": default_access_app_name_label,
@@ -856,6 +859,8 @@ def process_agent_container_start(payload, agent_id):
                 http_host_header_indexed_val = get_label(labels, f"{index}.httpHostHeader", default_http_host_header_label)
                 http2_origin_indexed_val = get_label(labels, f"{index}.http2_origin", str(http2_origin_label).lower())
                 http2_origin_indexed = http2_origin_indexed_val.lower() in ["true", "1", "t", "yes"]
+                disable_chunked_encoding_indexed_val = get_label(labels, f"{index}.disable_chunked_encoding", str(disable_chunked_encoding_label).lower())
+                disable_chunked_encoding_indexed = disable_chunked_encoding_indexed_val.lower() in ["true", "1", "t", "yes"]
 
                 access_groups_indexed = get_label(labels, f"{index}.access.groups")
                 raw_access_group_indexed = get_label(labels, f"{index}.access.group") if not access_groups_indexed else None
@@ -909,6 +914,7 @@ def process_agent_container_start(payload, agent_id):
                         "origin_server_name": originsrvname_indexed_val.strip() if originsrvname_indexed_val else None,
                         "http_host_header": http_host_header_indexed_val.strip() if http_host_header_indexed_val else None,
                         "http2_origin": http2_origin_indexed,
+                        "disable_chunked_encoding": disable_chunked_encoding_indexed,
                         "access_group": access_group_indexed,
                         "access_policy_type": access_policy_type_indexed,
                         "access_app_name": access_app_name_indexed,
@@ -946,7 +952,9 @@ def process_agent_container_start(payload, agent_id):
                 zone_name_from_item = config_item["zone_name"]
                 no_tls_verify_from_item = config_item["no_tls_verify"]
                 origin_server_name_from_item = config_item.get("origin_server_name")
+                http_host_header_from_item = config_item.get("http_host_header")
                 http2_origin_from_item = config_item.get("http2_origin", False)
+                disable_chunked_encoding_from_item = config_item.get("disable_chunked_encoding", False)
 
                 target_zone_id = None
                 if zone_name_from_item:
@@ -996,6 +1004,9 @@ def process_agent_container_start(payload, agent_id):
                         if existing_rule.get("http2_origin") != http2_origin_from_item:
                             existing_rule["http2_origin"] = http2_origin_from_item
                             rule_data_changed = True
+                        if existing_rule.get("disable_chunked_encoding") != disable_chunked_encoding_from_item:
+                            existing_rule["disable_chunked_encoding"] = disable_chunked_encoding_from_item
+                            rule_data_changed = True
                         if existing_rule.get("tunnel_name") != assigned_tunnel_name:
                             existing_rule["tunnel_name"] = assigned_tunnel_name
                             rule_data_changed = True
@@ -1033,6 +1044,7 @@ def process_agent_container_start(payload, agent_id):
                             "origin_server_name": origin_server_name_from_item,
                             "http_host_header": config_item.get("http_host_header"),
                             "http2_origin": http2_origin_from_item,
+                            "disable_chunked_encoding": disable_chunked_encoding_from_item,
                             "access_app_id": None,
                             "access_policy_type": None,
                             "access_app_config_hash": None,

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -1237,6 +1237,7 @@ def ui_add_manual_rule_route():
     no_tls_verify = request.form.get('manual_no_tls_verify') == 'on'
     origin_server_name_input = request.form.get('manual_origin_server_name', '').strip()
     manual_http_host_header = request.form.get('manual_http_host_header', '').strip()
+    http2_origin = request.form.get('manual_http2_origin') == 'on'
 
     manual_access_group_ids = request.form.getlist('manual_access_groups')
     manual_access_policy_type = request.form.get('manual_access_policy_type', 'none').strip().lower()
@@ -1489,6 +1490,7 @@ def ui_add_manual_rule_route():
             "no_tls_verify": no_tls_verify,
             "origin_server_name": origin_server_name_input or None,
             "http_host_header": manual_http_host_header or None,
+            "http2_origin": http2_origin,
             "source": "manual",
             "access_app_id": access_app_id,
             "access_policy_type": access_policy_type,
@@ -1591,7 +1593,8 @@ def ui_edit_manual_rule_route():
     no_tls_verify = request.form.get('edit_no_tls_verify') == 'on'
     origin_server_name_input = request.form.get('edit_origin_server_name', '').strip()
     manual_http_host_header = request.form.get('edit_http_host_header', '').strip()
-    
+    http2_origin = request.form.get('edit_http2_origin') == 'on'
+
     if not domain_name_input or not service_type_input:
         cloudflared_agent_state["last_action_status"] = "Error: Domain and service type required."
         return redirect(url_for('web.status_page'))
@@ -1775,6 +1778,7 @@ def ui_edit_manual_rule_route():
             "no_tls_verify": no_tls_verify,
             "origin_server_name": origin_server_name_input or None,
             "http_host_header": manual_http_host_header or None,
+            "http2_origin": http2_origin,
             "access_app_id": access_app_id,
             "access_policy_type": access_policy_type,
             "access_app_config_hash": access_app_config_hash,

--- a/dockflare/app/web/routes.py
+++ b/dockflare/app/web/routes.py
@@ -1238,6 +1238,7 @@ def ui_add_manual_rule_route():
     origin_server_name_input = request.form.get('manual_origin_server_name', '').strip()
     manual_http_host_header = request.form.get('manual_http_host_header', '').strip()
     http2_origin = request.form.get('manual_http2_origin') == 'on'
+    disable_chunked_encoding = request.form.get('manual_disable_chunked_encoding') == 'on'
 
     manual_access_group_ids = request.form.getlist('manual_access_groups')
     manual_access_policy_type = request.form.get('manual_access_policy_type', 'none').strip().lower()
@@ -1491,6 +1492,7 @@ def ui_add_manual_rule_route():
             "origin_server_name": origin_server_name_input or None,
             "http_host_header": manual_http_host_header or None,
             "http2_origin": http2_origin,
+            "disable_chunked_encoding": disable_chunked_encoding,
             "source": "manual",
             "access_app_id": access_app_id,
             "access_policy_type": access_policy_type,
@@ -1594,6 +1596,7 @@ def ui_edit_manual_rule_route():
     origin_server_name_input = request.form.get('edit_origin_server_name', '').strip()
     manual_http_host_header = request.form.get('edit_http_host_header', '').strip()
     http2_origin = request.form.get('edit_http2_origin') == 'on'
+    disable_chunked_encoding = request.form.get('edit_disable_chunked_encoding') == 'on'
 
     if not domain_name_input or not service_type_input:
         cloudflared_agent_state["last_action_status"] = "Error: Domain and service type required."
@@ -1779,6 +1782,7 @@ def ui_edit_manual_rule_route():
             "origin_server_name": origin_server_name_input or None,
             "http_host_header": manual_http_host_header or None,
             "http2_origin": http2_origin,
+            "disable_chunked_encoding": disable_chunked_encoding,
             "access_app_id": access_app_id,
             "access_policy_type": access_policy_type,
             "access_app_config_hash": access_app_config_hash,


### PR DESCRIPTION
## [v3.0.5] - 2025-10-14

### Added
- **HTTP/2 Origin Support:** Added support for enabling HTTP/2 protocol between `cloudflared` and origin services via the new `dockflare.http2_origin` label and UI controls. Required for gRPC services. Only applies to HTTP/HTTPS services.
- **Disable Chunked Encoding Support:** Added support for disabling chunked transfer encoding over HTTP/1.1 via the new `dockflare.disable_chunked_encoding` label and UI controls. Useful for WSGI servers (Flask, Django, FastAPI) and other origins that don't properly support chunked requests. Only applies to HTTP/HTTPS services.
