### PR TITLE
Authlib to v1.6.5 - (vulnerability DoS Attack)

### DIFF
--- a/dockflare/requirements.txt
+++ b/dockflare/requirements.txt
@@ -24,7 +24,7 @@ flask-login==0.6.3
     # via -r dockflare/requirements.in
 flask-wtf==1.2.2
     # via -r dockflare/requirements.in
-Authlib==1.6.4
+Authlib==1.6.5
     # via OAuth2 integration
 idna==3.10
     # via requests


### PR DESCRIPTION
Authlib’s JOSE implementation accepts unbounded JWS/JWT header and signature segments. A remote attacker can craft a token whose base64url‑encoded header or signature spans hundreds of megabytes. During verification, Authlib decodes and parses the full input before it is rejected, driving CPU and memory consumption to hostile levels and enabling denial of service.

Impact

Attack vector: unauthenticated network attacker submits a malicious JWS/JWT.

Effect: base64 decode + JSON/crypto processing of huge buffers pegs CPU and allocates large amounts of RAM; a single request can exhaust service capacity.

Observed behaviour: on a test host, the legacy code verified a 500 MB header, consuming ~4 GB RSS and ~9 s CPU before failing.

Severity: High. CVSS v3.1: AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (7.5).

Affected Versions
Authlib ≤ 1.6.3 (and earlier) when verifying JWS/JWT tokens. Later snapshots with 256 KB header/signature limits are not affected.