### PR TITLE
fix: support cfat_ token format for email suite setup

### DIFF
--- a/dockflare/app/core/email_manager.py
+++ b/dockflare/app/core/email_manager.py
@@ -63,7 +63,7 @@ def enable_email_routing(zone_id):
 def enable_email_sending(zone_id, zone_name):
     try:
         subdomain = f"mail.{zone_name}"
-        res = cf_api_request('POST', f'/zones/{zone_id}/email/sending/subdomains', data={"name": subdomain})
+        res = cf_api_request('POST', f'/zones/{zone_id}/email/sending/subdomains', json_data={"name": subdomain})
         logging.info(f"Email sending enabled for {zone_name} (subdomain: {subdomain})")
         return res
     except Exception as e:
@@ -191,7 +191,11 @@ def create_r2_bucket(bucket_name):
 
 def get_r2_s3_credentials():
     import hashlib
-    token_verify = cf_api_request('GET', f'/accounts/{config.CF_ACCOUNT_ID}/tokens/verify')
+    token = getattr(config, 'CF_API_TOKEN', '') or ''
+    if token.startswith('cfat_'):
+        token_verify = cf_api_request('GET', f'/accounts/{config.CF_ACCOUNT_ID}/tokens/verify')
+    else:
+        token_verify = cf_api_request('GET', '/user/tokens/verify')
     token_id = token_verify.get('result', {}).get('id', '')
     secret = hashlib.sha256(config.CF_API_TOKEN.encode()).hexdigest()
     return {

--- a/dockflare/app/web/forms.py
+++ b/dockflare/app/web/forms.py
@@ -106,6 +106,6 @@ class CloudflareCredentialsForm(FlaskForm):
     )
     cf_api_token = PasswordField(
         'Cloudflare API Token',
-        validators=[Optional(), Length(min=40, max=40, message="API Token must be 40 characters long.")]
+        validators=[Optional(), Length(min=40, max=100, message="API Token must be at least 40 characters long.")]
     )
     submit_cloudflare_credentials = SubmitField('Update Cloudflare Credentials')


### PR DESCRIPTION
Cloudflare's new API token format (cfat_ prefix, 47 chars) was silently rejected by the credential form validator which enforced a strict 40-char limit. This blocked users from saving the new token, causing all subsequent CF API calls to fail with 401.
Also fixes enable_email_sending() passing `data=` instead of `json_data=` to cf_api_request(), which caused a TypeError on every domain setup. Fixes #355, #356