### PR TITLE
Fix multi-zone DNS reconciliation

### DIFF
--- a/dockflare/app/core/cloudflare_api.py
+++ b/dockflare/app/core/cloudflare_api.py
@@ -23,6 +23,7 @@ import threading
 from flask import current_app
 from app import config
 from app.core.cache import cache, get_dns_records_cache_key, DNS_RECORDS_CACHE_TIMEOUT, CACHE_ENABLED
+from app.core.zone_detection import find_best_zone_for_hostname
 
 zone_id_cache = {}  
 zone_details_by_id_cache = {}  
@@ -560,6 +561,14 @@ def list_account_zones(force_refresh=False):
     zones.sort(key=lambda x: x.get("name", "").lower())
     cache.set(cache_key, zones, timeout=300)
     return zones
+
+def detect_zone_for_hostname(hostname, zones=None):
+    try:
+        candidate_zones = zones if zones is not None else list_account_zones()
+    except Exception as detection_error:
+        logging.error(f"Failed to retrieve zones for hostname '{hostname}': {detection_error}")
+        return None, None
+    return find_best_zone_for_hostname(hostname, candidate_zones)
 
 def get_current_cf_config(tunnel_id_to_query):
     if not tunnel_id_to_query:

--- a/dockflare/app/core/docker_handler.py
+++ b/dockflare/app/core/docker_handler.py
@@ -28,7 +28,7 @@ from app import config, docker_client, cloudflared_agent_state, tunnel_state, pu
 
 from app.core.state_manager import managed_rules, state_lock, save_state, tailscale_rules, upsert_tailscale_rule
 from app.core.tunnel_manager import update_cloudflare_config
-from app.core.cloudflare_api import create_cloudflare_dns_record, get_zone_id_from_name, list_account_zones
+from app.core.cloudflare_api import create_cloudflare_dns_record, get_zone_id_from_name, detect_zone_for_hostname
 from app.core.access_manager import handle_access_policy_from_labels
 from app.core.utils import get_rule_key, get_label, normalize_access_group_value
 
@@ -754,28 +754,4 @@ def start_event_listeners(stop_event):
         
     return threads
 def _detect_zone_for_hostname(hostname):
-    if not hostname:
-        return None, None
-    try:
-        zones = list_account_zones()
-    except Exception as detection_error:
-        logging.error(f"DOCKER_HANDLER: Failed to retrieve zones for hostname '{hostname}': {detection_error}")
-        return None, None
-    if not zones:
-        return None, None
-    hostname_lower = hostname.lower().lstrip('.')
-    if hostname_lower.startswith('*.'):
-        hostname_lower = hostname_lower[2:]
-    matches = []
-    for zone in zones:
-        zone_name = (zone.get('name') or '').lower()
-        if not zone_name:
-            continue
-        if hostname_lower == zone_name or hostname_lower.endswith(f".{zone_name}"):
-            matches.append(zone)
-    if not matches:
-        return None, None
-    best_length = max(len(zone.get('name') or '') for zone in matches)
-    best_zones = [zone for zone in matches if len(zone.get('name') or '') == best_length]
-    chosen_zone = best_zones[0]
-    return chosen_zone.get('id'), chosen_zone.get('name')
+    return detect_zone_for_hostname(hostname)

--- a/dockflare/app/core/reconciler.py
+++ b/dockflare/app/core/reconciler.py
@@ -26,6 +26,7 @@ from flask import current_app
 from app.core.state_manager import managed_rules, state_lock, save_state, get_agent, update_agent, tailscale_rules, upsert_tailscale_rule, remove_tailscale_rule, list_tailscale_rules
 from app.core.cloudflare_api import (
     get_zone_id_from_name, 
+    detect_zone_for_hostname,
     create_cloudflare_dns_record,
     delete_cloudflare_dns_record
 )
@@ -161,6 +162,26 @@ def _get_hostname_configs_from_container(container_obj):
         idx += 1
     return hostnames_configs
 
+def _resolve_zone_for_hostname(hostname, zone_name=None):
+    target_zone_id = None
+    resolved_zone_name = zone_name
+
+    if zone_name:
+        target_zone_id = get_zone_id_from_name(zone_name)
+        if not target_zone_id:
+            logging.error(f"[Reconcile] Failed Zone ID lookup for '{zone_name}' (hostname {hostname}). Attempting auto-detect.")
+
+    if not target_zone_id:
+        detected_zone_id, detected_zone_name = detect_zone_for_hostname(hostname)
+        if detected_zone_id:
+            target_zone_id = detected_zone_id
+            resolved_zone_name = detected_zone_name or resolved_zone_name
+
+    if not target_zone_id:
+        target_zone_id = current_app.config.get('CF_ZONE_ID')
+
+    return target_zone_id, resolved_zone_name
+
 
 def reconcile_agent_report(agent_id, reported_containers):
     """
@@ -229,14 +250,11 @@ def reconcile_agent_report(agent_id, reported_containers):
             with state_lock:
                 for rule_key, desired in desired_configs.items():
                     existing = managed_rules.get(rule_key)
-                    target_zone_id = None
-                    try:
-                        target_zone_id = get_zone_id_from_name(desired.get("zone_name")) if desired.get("zone_name") else current_app.config.get('CF_ZONE_ID')
-                    except Exception:
-                        target_zone_id = current_app.config.get('CF_ZONE_ID')
+                    target_zone_id, resolved_zone_name = _resolve_zone_for_hostname(desired.get("hostname"), desired.get("zone_name"))
                     if not target_zone_id:
                         logging.warning(f"[Reconcile-Agent] Could not determine Zone ID for rule {rule_key} while reconciling agent {agent_id}. Skipping.")
                         continue
+                    desired["zone_name"] = resolved_zone_name
 
                     if existing:
                         if existing.get("source") == "manual":
@@ -260,6 +278,9 @@ def reconcile_agent_report(agent_id, reported_containers):
                         if existing.get("zone_id") != target_zone_id:
                             existing["zone_id"] = target_zone_id
                             changed = True
+                        if existing.get("zone_name") != resolved_zone_name:
+                            existing["zone_name"] = resolved_zone_name
+                            changed = True
                         if existing.get("no_tls_verify") != desired.get("no_tls_verify"):
                             existing["no_tls_verify"] = desired.get("no_tls_verify")
                             changed = True
@@ -279,6 +300,7 @@ def reconcile_agent_report(agent_id, reported_containers):
                             "status": "active",
                             "delete_at": None,
                             "zone_id": target_zone_id,
+                            "zone_name": resolved_zone_name,
                             "no_tls_verify": desired.get("no_tls_verify"),
                             "origin_server_name": desired.get("origin_server_name"),
                             "http_host_header": desired.get("http_host_header"),
@@ -397,10 +419,11 @@ def _run_reconciliation_logic():
                 if existing_rule and existing_rule.get("source") == "manual":
                     continue
 
-                target_zone_id = get_zone_id_from_name(desired_details["zone_name"]) if desired_details["zone_name"] else current_app.config.get('CF_ZONE_ID')
+                target_zone_id, resolved_zone_name = _resolve_zone_for_hostname(desired_details["hostname"], desired_details.get("zone_name"))
                 if not target_zone_id:
                     logging.error(f"[Reconcile] No zone ID for {rule_key}, skipping its reconciliation.")
                     continue
+                desired_details["zone_name"] = resolved_zone_name
                 
                 if not existing_rule:
                     managed_rules[rule_key] = {
@@ -412,6 +435,7 @@ def _run_reconciliation_logic():
                         "no_tls_verify": desired_details["no_tls_verify"],
                         "origin_server_name": desired_details.get("origin_server_name"),
                         "http_host_header": desired_details.get("http_host_header"),
+                        "zone_name": resolved_zone_name,
                         "access_app_id": None, "access_policy_type": None, "access_app_config_hash": None,
                         "access_policy_ui_override": False, "rule_ui_override": False, "source": "docker",
                         "access_group_id": None,
@@ -440,6 +464,9 @@ def _run_reconciliation_logic():
                         existing_rule["zone_id"] = target_zone_id
                         changed_in_reconcile = True
                         needs_tunnel_config_update = True 
+                    if existing_rule.get("zone_name") != resolved_zone_name:
+                        existing_rule["zone_name"] = resolved_zone_name
+                        changed_in_reconcile = True
                     if existing_rule.get("container_id") != desired_details["container_id"]:
                         existing_rule["container_id"] = desired_details["container_id"]
                         changed_in_reconcile = True

--- a/dockflare/app/core/zone_detection.py
+++ b/dockflare/app/core/zone_detection.py
@@ -1,0 +1,40 @@
+# DockFlare: Automates Cloudflare Tunnel ingress from Docker labels.
+# Copyright (C) 2025 ChrispyBacon-Dev <https://github.com/ChrispyBacon-dev/DockFlare>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+
+def find_best_zone_for_hostname(hostname, zones):
+    if not hostname or not zones:
+        return None, None
+
+    hostname_lower = hostname.lower().lstrip('.')
+    if hostname_lower.startswith('*.'):
+        hostname_lower = hostname_lower[2:]
+
+    matches = []
+    for zone in zones:
+        zone_name = (zone.get('name') or '').lower()
+        if not zone_name:
+            continue
+        if hostname_lower == zone_name or hostname_lower.endswith(f".{zone_name}"):
+            matches.append(zone)
+
+    if not matches:
+        return None, None
+
+    best_length = max(len(zone.get('name') or '') for zone in matches)
+    best_zones = [zone for zone in matches if len(zone.get('name') or '') == best_length]
+    chosen_zone = best_zones[0]
+    return chosen_zone.get('id'), chosen_zone.get('name')

--- a/dockflare/tests/test_zone_detection.py
+++ b/dockflare/tests/test_zone_detection.py
@@ -1,0 +1,44 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ZONE_DETECTION_PATH = pathlib.Path(__file__).resolve().parents[1] / "app" / "core" / "zone_detection.py"
+spec = importlib.util.spec_from_file_location("zone_detection", ZONE_DETECTION_PATH)
+assert spec is not None and spec.loader is not None
+zone_detection = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(zone_detection)
+find_best_zone_for_hostname = zone_detection.find_best_zone_for_hostname
+
+
+class ZoneDetectionTest(unittest.TestCase):
+    def test_selects_longest_matching_zone_suffix(self):
+        zones = [
+            {"id": "primary-zone", "name": "example.com"},
+            {"id": "secondary-zone", "name": "secondary.example.com"},
+        ]
+
+        zone_id, zone_name = find_best_zone_for_hostname("app.secondary.example.com", zones)
+
+        self.assertEqual(zone_id, "secondary-zone")
+        self.assertEqual(zone_name, "secondary.example.com")
+
+    def test_matches_wildcard_hostname_against_zone(self):
+        zones = [{"id": "secondary-zone", "name": "secondary.example.com"}]
+
+        zone_id, zone_name = find_best_zone_for_hostname("*.secondary.example.com", zones)
+
+        self.assertEqual(zone_id, "secondary-zone")
+        self.assertEqual(zone_name, "secondary.example.com")
+
+    def test_returns_empty_result_when_no_zone_matches(self):
+        zones = [{"id": "primary-zone", "name": "example.com"}]
+
+        zone_id, zone_name = find_best_zone_for_hostname("app.other.test", zones)
+
+        self.assertIsNone(zone_id)
+        self.assertIsNone(zone_name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reuses Docker handler zone auto-detection in reconciliation paths instead of falling back directly to the primary zone.
- Stores the resolved `zone_name` alongside `zone_id` for reconciled Docker and agent rules.
- Adds focused unit coverage for longest-suffix zone matching, including wildcard hostnames.

## Why
When a hostname belongs to a secondary Cloudflare zone and no explicit `dockflare.zonename` label is set, reconciliation could choose the configured primary `CF_ZONE_ID`. That caused DNS create/update calls for `app.secondary.example` to be sent to the primary zone instead of the matching secondary zone.

Fixes #377.

## Test plan
- [x] `python3 -m unittest dockflare/tests/test_zone_detection.py -v`
- [x] `python3 -m py_compile dockflare/app/core/cloudflare_api.py dockflare/app/core/docker_handler.py dockflare/app/core/reconciler.py dockflare/app/core/zone_detection.py dockflare/tests/test_zone_detection.py`
- [x] `git diff --check`

Note: I also installed the pinned `dockflare/requirements.txt` in a local venv and reran the new unit test successfully. A full app import on this runner uses Python 3.11 and hits an existing nested f-string syntax issue in `dockflare/app/web/routes.py`; this project’s requirements are generated for Python 3.13, and I did not change that unrelated file.
