### PR TITLE
Update health check docs to use wget

### DIFF
--- a/dockflare/app/templates/docs/ch-barnduetsch/Health-Checks.md
+++ b/dockflare/app/templates/docs/ch-barnduetsch/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### Was d `healthcheck`-Wärt bedüte
 
-* `test`: Dr Befehl, wo Docker im Container usfüehrt. `curl -f` prüeft, öb `/ping` e gültigi Antwort git.
+* `test`: Dr Befehl, wo Docker im Container usfüehrt. `wget --spider` prüeft, öb `/ping` e gültigi Antwort git.
 * `interval`: Docker macht dä Check alli 90 Sekunde.
 * `timeout`: So lang wartet Docker höchstens uf e Antwort.
 * `retries`: Nach dr dritte fehlgschlagene Prüefig gilt dr Container als `unhealthy`.

--- a/dockflare/app/templates/docs/de/Health-Checks.md
+++ b/dockflare/app/templates/docs/de/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### Aufschlüsselung der `healthcheck`-Konfiguration:
 
-*   `test`: Dies ist der Befehl, den Docker innerhalb des Containers ausführt. `curl -f` sendet eine HTTP-Anfrage an den `/ping`-Endpunkt und bricht mit einem Statuscode ungleich null ab, wenn die Antwort nicht HTTP 200 OK lautet.
+*   `test`: Dies ist der Befehl, den Docker innerhalb des Containers ausführt. `wget --spider` sendet eine HTTP-Anfrage an den `/ping`-Endpunkt und bricht mit einem Statuscode ungleich null ab, wenn die Antwort nicht HTTP 200 OK lautet.
 *   `interval`: Docker führt diese Prüfung alle 90 Sekunden aus.
 *   `timeout`: Docker wartet bis zu 10 Sekunden auf die Ausführung des Befehls.
 *   `retries`: Schlägt die Prüfung 3-mal hintereinander fehl, markiert Docker den Container als `unhealthy` (ungesund).

--- a/dockflare/app/templates/docs/en/Health-Checks.md
+++ b/dockflare/app/templates/docs/en/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### Breakdown of the `healthcheck` configuration:
 
-*   `test`: This is the command that Docker runs inside the container. `curl -f` will make an HTTP request to the `/ping` endpoint and will exit with a non-zero status code if the response is not HTTP 200 OK.
+*   `test`: This is the command that Docker runs inside the container. `wget --spider` will make an HTTP request to the `/ping` endpoint and will exit with a non-zero status code if the response is not HTTP 200 OK.
 *   `interval`: Docker will run this check every 90 seconds.
 *   `timeout`: Docker will wait up to 10 seconds for the command to complete.
 *   `retries`: If the check fails 3 times in a row, Docker will mark the container as `unhealthy`.

--- a/dockflare/app/templates/docs/es/Health-Checks.md
+++ b/dockflare/app/templates/docs/es/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### Desglose de la configuración `healthcheck`:
 
-* `test`: Este es el comando que Docker ejecuta dentro del contenedor. `curl -f` realizará una solicitud HTTP al punto final `/ping` y saldrá con un código de estado distinto de cero si la respuesta no es HTTP 200 OK.
+* `test`: Este es el comando que Docker ejecuta dentro del contenedor. `wget --spider` realizará una solicitud HTTP al punto final `/ping` y saldrá con un código de estado distinto de cero si la respuesta no es HTTP 200 OK.
 * `interval`: Docker ejecutará esta verificación cada 90 segundos.
 * `timeout`: Docker esperará hasta 10 segundos para que se complete el comando.
 * `retries`: Si la verificación falla 3 veces seguidas, Docker marcará el contenedor como `unhealthy`.

--- a/dockflare/app/templates/docs/fr/Health-Checks.md
+++ b/dockflare/app/templates/docs/fr/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### Décomposition de la configuration `healthcheck` :
 
-* `test` : il s'agit de la commande que Docker exécute à l'intérieur du conteneur. `curl -f` effectuera une requête HTTP au point de terminaison `/ping` et se terminera avec un code d'état différent de zéro si la réponse n'est pas HTTP 200 OK.
+* `test` : il s'agit de la commande que Docker exécute à l'intérieur du conteneur. `wget --spider` effectuera une requête HTTP au point de terminaison `/ping` et se terminera avec un code d'état différent de zéro si la réponse n'est pas HTTP 200 OK.
 * `interval` : Docker exécutera cette vérification toutes les 90 secondes.
 * `timeout` : Docker attendra jusqu'à 10 secondes pour que la commande soit terminée.
 * `retries` : si la vérification échoue 3 fois de suite, Docker marquera le conteneur comme `unhealthy`.

--- a/dockflare/app/templates/docs/id/Health-Checks.md
+++ b/dockflare/app/templates/docs/id/Health-Checks.md
@@ -23,7 +23,7 @@ services:
     restart: unless-stopped
     # ... pengaturan lain
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       interval: 1m30s
       timeout: 10s
       retries: 3

--- a/dockflare/app/templates/docs/it/Health-Checks.md
+++ b/dockflare/app/templates/docs/it/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### Suddivisione della configurazione `healthcheck`:
 
-* `test`: questo è il comando che Docker esegue all'interno del contenitore. `curl -f` effettuerà una richiesta HTTP all'endpoint `/ping` e uscirà con un codice di stato diverso da zero se la risposta non è HTTP 200 OK.
+* `test`: questo è il comando che Docker esegue all'interno del contenitore. `wget --spider` effettuerà una richiesta HTTP all'endpoint `/ping` e uscirà con un codice di stato diverso da zero se la risposta non è HTTP 200 OK.
 * `interval`: Docker eseguirà questo controllo ogni 90 secondi.
 * `timeout`: Docker attenderà fino a 10 secondi per il completamento del comando.
 * `retries`: se il controllo fallisce 3 volte di seguito, Docker contrassegnerà il contenitore come `unhealthy`.

--- a/dockflare/app/templates/docs/ja/Health-Checks.md
+++ b/dockflare/app/templates/docs/ja/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### `healthcheck` 設定の内訳
 
-* `test`: Docker がコンテナ内で実行するコマンドです。`curl -f` は `/ping` に HTTP リクエストを送り、応答が HTTP 200 OK でなければゼロ以外の終了コードを返します。
+* `test`: Docker がコンテナ内で実行するコマンドです。`wget --spider` は `/ping` に HTTP リクエストを送り、応答が HTTP 200 OK でなければゼロ以外の終了コードを返します。
 * `interval`: Docker は 90 秒ごとにこのチェックを実行します。
 * `timeout`: コマンド完了まで最大 10 秒待機します。
 * `retries`: チェックが 3 回連続で失敗すると、Docker はコンテナを `unhealthy` と判定します。

--- a/dockflare/app/templates/docs/pl/Health-Checks.md
+++ b/dockflare/app/templates/docs/pl/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### Podział konfiguracji `healthcheck`:
 
-* `test`: To jest polecenie uruchamiane przez Dockera wewnątrz kontenera. `curl -f` wyśle żądanie HTTP do punktu końcowego `/ping` i zakończy działanie z niezerowym kodem stanu, jeśli odpowiedź nie będzie HTTP 200 OK.
+* `test`: To jest polecenie uruchamiane przez Dockera wewnątrz kontenera. `wget --spider` wyśle żądanie HTTP do punktu końcowego `/ping` i zakończy działanie z niezerowym kodem stanu, jeśli odpowiedź nie będzie HTTP 200 OK.
 * `interval`: Docker będzie uruchamiał tę kontrolę co 90 sekund.
 * `timeout`: Docker będzie czekać do 10 sekund na wykonanie polecenia.
 * `retries`: Jeśli sprawdzenie nie powiedzie się 3 razy z rzędu, Docker oznaczy kontener jako `unhealthy`.

--- a/dockflare/app/templates/docs/sk/Health-Checks.md
+++ b/dockflare/app/templates/docs/sk/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... ďalšie nastavenia
     healthcheck:
       # Príkaz na kontrolu stavu.
-      # curl vykoná HTTP požiadavku na ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget je dostupný v image DockFlare a kontroluje ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # Ako často spúšťať kontrolu
       interval: 1m30s
       # Ako dlho čakať na odpoveď
@@ -38,7 +38,7 @@ services:
 
 ### Rozbor konfigurácie `healthcheck`:
 
-*   `test`: Príkaz, ktorý Docker spúšťa vnútri kontajnera. `curl -f` vykoná HTTP požiadavku na endpoint `/ping` a skončí s nenulovým stavovým kódom, ak odpoveď nie je HTTP 200 OK.
+*   `test`: Príkaz, ktorý Docker spúšťa vnútri kontajnera. `wget --spider` vykoná HTTP požiadavku na endpoint `/ping` a skončí s nenulovým stavovým kódom, ak odpoveď nie je HTTP 200 OK.
 *   `interval`: Docker spustí túto kontrolu každých 90 sekúnd.
 *   `timeout`: Docker počká na dokončenie príkazu až 10 sekúnd.
 *   `retries`: Ak kontrola zlyhá 3-krát po sebe, Docker označí kontajner ako `unhealthy`.

--- a/dockflare/app/templates/docs/zh/Health-Checks.md
+++ b/dockflare/app/templates/docs/zh/Health-Checks.md
@@ -24,8 +24,8 @@ services:
     # ... other settings
     healthcheck:
       # The command to run to check health.
-      # curl is used to make an HTTP request to the ping endpoint.
-      test: ["CMD", "curl", "-f", "http://localhost:5000/ping"]
+      # wget is available in the DockFlare image and checks the ping endpoint.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5000/ping"]
       # How often to run the check
       interval: 1m30s
       # How long to wait for a response
@@ -38,7 +38,7 @@ services:
 
 ### `healthcheck` 配置的细分：
 
-* `test`：这是 Docker 在容器内运行的命令。`curl -f` 将向 `/ping` 端点发出 HTTP 请求，如果响应不是 HTTP 200 OK，则将以非零状态代码退出。
+* `test`：这是 Docker 在容器内运行的命令。`wget --spider` 将向 `/ping` 端点发出 HTTP 请求，如果响应不是 HTTP 200 OK，则将以非零状态代码退出。
 * `interval`：Docker 将每 90 秒运行一次此检查。
 * `timeout`：Docker 将等待最多 10 秒以完成命令。
 * `retries`：如果连续3次检查失败，Docker会将容器标记为`unhealthy`。


### PR DESCRIPTION
## Summary
- Updates the Docker Compose healthcheck example to use `wget --spider` instead of `curl -f`.
- Applies the same command to every localized `Health-Checks.md` page so the docs stay consistent.

## Why
- Fixes #382.
- The DockFlare image does not include `curl`, so the documented healthcheck command fails even though `/ping` is available.
- `wget` is available in the image and can check `/ping` without downloading the response body.

## Testing
- [x] Ran a deterministic docs check over all 11 `Health-Checks.md` files to verify no `curl` references remain, each file contains the `wget --spider` healthcheck command, and the `/ping` target is preserved.
- [x] `git diff --check`
