### PR TITLE
Fix SimpleCache pattern invalidation

### DIFF
--- a/dockflare/app/core/cache.py
+++ b/dockflare/app/core/cache.py
@@ -15,12 +15,15 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 # dockflare/app/core/cache.py
+import fnmatch
 import logging
 import os
-import time
 import threading
+import time
+
 import redis
 from flask_caching import Cache
+
 from app import config
 
 cache_config = {
@@ -130,8 +133,16 @@ def _delete_keys_by_pattern(pattern):
                     redis_client.delete(*keys)
                     logging.debug(f"Deleted {len(keys)} keys matching pattern {full_pattern}")
                 cursor = int(cursor)
+        elif cache.config['CACHE_TYPE'] == 'SimpleCache' and hasattr(cache, 'cache') and hasattr(cache.cache, '_cache'):
+            matching_keys = [
+                key for key in list(cache.cache._cache)
+                if fnmatch.fnmatch(key, pattern)
+            ]
+            for key in matching_keys:
+                cache.cache.delete(key)
+            logging.debug(f"Deleted {len(matching_keys)} SimpleCache keys matching pattern {pattern}")
         else:
-            logging.warning("Pattern-based cache invalidation is only supported with RedisCache")
+            logging.debug("Pattern-based cache invalidation skipped for unsupported cache backend")
     except Exception as e:
         logging.error(f"Error deleting keys by pattern {pattern}: {e}", exc_info=True)
 

--- a/dockflare/tests/test_cache_pattern_invalidation.py
+++ b/dockflare/tests/test_cache_pattern_invalidation.py
@@ -1,0 +1,41 @@
+import logging
+
+from app.core import cache as cache_module
+from flask import Flask
+from flask_caching import Cache
+
+
+def make_simple_cache():
+    app = Flask(__name__)
+    simple_cache = Cache(config={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 300})
+    simple_cache.init_app(app)
+    return simple_cache
+
+
+def test_delete_keys_by_pattern_removes_matching_simple_cache_keys(monkeypatch):
+    simple_cache = make_simple_cache()
+    simple_cache.set("dns_records:zone-a:tunnel-1", "a")
+    simple_cache.set("dns_records:zone-a:tunnel-2", "b")
+    simple_cache.set("dns_records:zone-b:tunnel-1", "c")
+    simple_cache.set("zone_details:zone-a", "keep")
+
+    monkeypatch.setattr(cache_module, "cache", simple_cache)
+
+    cache_module._delete_keys_by_pattern("dns_records:zone-a:*")
+
+    assert simple_cache.get("dns_records:zone-a:tunnel-1") is None
+    assert simple_cache.get("dns_records:zone-a:tunnel-2") is None
+    assert simple_cache.get("dns_records:zone-b:tunnel-1") == "c"
+    assert simple_cache.get("zone_details:zone-a") == "keep"
+
+
+def test_simple_cache_pattern_invalidation_does_not_emit_redis_warning(monkeypatch, caplog):
+    simple_cache = make_simple_cache()
+    simple_cache.set("dns_records:zone-a:tunnel-1", "a")
+    monkeypatch.setattr(cache_module, "cache", simple_cache)
+
+    with caplog.at_level(logging.WARNING):
+        cache_module._delete_keys_by_pattern("dns_records:*")
+
+    assert "Pattern-based cache invalidation is only supported with RedisCache" not in caplog.text
+    assert simple_cache.get("dns_records:zone-a:tunnel-1") is None


### PR DESCRIPTION
## Summary
- Adds SimpleCache pattern invalidation for DNS/zone cache keys.
- Keeps Redis pattern invalidation unchanged.
- Downgrades unsupported-cache pattern invalidation from a user-facing warning to debug logging.

## Why
- Fixes #380.
- Installations without `REDIS_URL` intentionally use Flask-Caching's in-memory `SimpleCache`, but periodic DNS cache refresh currently logs `Pattern-based cache invalidation is only supported with RedisCache` even for the supported fallback mode.
- SimpleCache exposes its in-process key store, so DockFlare can delete matching local keys directly instead of warning on every pattern invalidation.

## Testing
- [x] `PYTHONPATH=dockflare .venv/bin/python -m pytest -q dockflare/tests/test_cache_pattern_invalidation.py`
- [x] `.venv/bin/python -m py_compile dockflare/app/core/cache.py dockflare/tests/test_cache_pattern_invalidation.py`
- [x] `git diff --check`

## Notes
- I also ran `ruff check` locally. It reports pre-existing repository-wide logging-style rules in `dockflare/app/core/cache.py`; the changed import block was fixed with `ruff --select I --fix`.
